### PR TITLE
Default to the FQDN for dev server webpack config

### DIFF
--- a/src/projects/webpack.js
+++ b/src/projects/webpack.js
@@ -169,7 +169,7 @@ module.exports.createConfig = (argv, config, isServer) => {
       ignored: /node_modules/
     },
     // Remember to strip before passing config to new WebpackDevServer
-    host: hostname(),
+    host: `${hostname()}.aus.aunty.abc.net.au`,
     port: DEV_SERVER_PORT
   }, projectTypeConfig.devServer || {}, config.devServer || {});
 


### PR DESCRIPTION
Without the FQDN there is trouble serving in a couple of scenarios:

1. CORS fails from www
2. Can't be loaded at all when on the VPN.