### PR TITLE
Added eslint & prettier configuration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,9 @@
+{
+  "extends": ["prettier"],
+  "parserOptions": {
+    "ecmaVersion": 8,
+    "ecmaFeatures": {
+      "jsx": true
+    }
+  }
+}

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,5 @@
 .editorconfig
+.eslintrc
+.prettierrc
 CONTRIBUTING.md
 assets

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "printWidth": 120,
+  "singleQuote": true
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,14 +14,12 @@ npm link
 
 This will link the globally-available `aunty` command to your clone.
 
-Before submitting a pull request, please check that your changes meet the code style enforced by `xo` by running:
-
-```bash
-npm test
-```
-
 To revert to your original global install, run:
 
 ```bash
 npm unlink
 ```
+
+## Style
+
+This project's codebase should be managed with [eslint](https://github.com/eslint/eslint) and [prettier](https://github.com/prettier/prettier). You should configure your editor to take advantage of this to maintain the code style specifed in `.eslintrc` and `.prettierrc`. If your editor has a format-on-save option and a Prettier plugin, even better!

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ If you don't need to override any of the project defaults, your entire aunty con
 
 - Colin Gourlay ([gourlay.colin@abc.net.au](mailto:gourlay.colin@abc.net.au))
 - Nathan Hoad ([hoad.nathan@abc.net.au](mailto:hoad.nathan@abc.net.au))
+- Simon Elvery ([elvery.simon@abc.net.au](mailto:elvery.simon@abc.net.au))
 
 ## Thanks
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@abcnews/aunty",
-  "version": "5.2.0",
+  "version": "5.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -42,7 +42,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-      "dev": true,
       "requires": {
         "acorn": "3.3.0"
       },
@@ -50,8 +49,7 @@
         "acorn": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-          "dev": true
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
         }
       }
     },
@@ -127,10 +125,9 @@
       }
     },
     "ansi-escapes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
-      "dev": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
     },
     "ansi-html": {
       "version": "0.0.7",
@@ -194,12 +191,6 @@
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
     },
-    "array-differ": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
-      "dev": true
-    },
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -231,8 +222,7 @@
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "asn1": {
       "version": "0.2.3",
@@ -1475,12 +1465,6 @@
         "electron-to-chromium": "1.3.18"
       }
     },
-    "buf-compare": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buf-compare/-/buf-compare-1.0.1.tgz",
-      "integrity": "sha1-/vKNqLgROgoNtEMLC2Rntpcws0o=",
-      "dev": true
-    },
     "buffer": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
@@ -1520,7 +1504,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true,
       "requires": {
         "callsites": "0.2.0"
       }
@@ -1528,8 +1511,7 @@
     "callsites": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
-      "dev": true
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
     },
     "camel-case": {
       "version": "3.0.0",
@@ -1665,8 +1647,7 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
-      "dev": true
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
     },
     "clap": {
       "version": "1.2.0",
@@ -1714,12 +1695,11 @@
       "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
     },
     "cli-cursor": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-      "dev": true,
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "requires": {
-        "restore-cursor": "1.0.1"
+        "restore-cursor": "2.0.0"
       }
     },
     "cli-spinners": {
@@ -1728,10 +1708,9 @@
       "integrity": "sha1-75h+09SDkaw9q5GAtAanQhgNbmo="
     },
     "cli-width": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-      "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
-      "dev": true
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
     },
     "cliui": {
       "version": "3.2.0",
@@ -1889,36 +1868,13 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
-      "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
-      "dev": true,
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "requires": {
         "inherits": "2.0.3",
-        "readable-stream": "2.0.6",
+        "readable-stream": "2.3.3",
         "typedarray": "0.0.6"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "0.10.31",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
       }
     },
     "configstore": {
@@ -1956,12 +1912,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
-    },
-    "contains-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
-      "dev": true
     },
     "content-disposition": {
       "version": "0.5.2",
@@ -2042,16 +1992,6 @@
             "object-assign": "4.1.1"
           }
         }
-      }
-    },
-    "core-assert": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/core-assert/-/core-assert-0.2.1.tgz",
-      "integrity": "sha1-+F4s+b/tKPdzzIs/pcW2m9wC/j8=",
-      "dev": true,
-      "requires": {
-        "buf-compare": "1.0.1",
-        "is-error": "2.2.1"
       }
     },
     "core-js": {
@@ -2435,15 +2375,6 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
-    "deep-assign": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
-      "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
-      "dev": true,
-      "requires": {
-        "is-obj": "1.0.1"
-      }
-    },
     "deep-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
@@ -2457,17 +2388,7 @@
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
-    },
-    "deep-strict-equal": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/deep-strict-equal/-/deep-strict-equal-0.2.0.tgz",
-      "integrity": "sha1-SgeBR6irV/ag1PVUckPNIvROtOQ=",
-      "dev": true,
-      "requires": {
-        "core-assert": "0.2.1"
-      }
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "defined": {
       "version": "1.0.0",
@@ -2565,7 +2486,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
       "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
-      "dev": true,
       "requires": {
         "esutils": "2.0.2",
         "isarray": "1.0.0"
@@ -2649,15 +2569,6 @@
       "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
       "requires": {
         "once": "1.4.0"
-      }
-    },
-    "enhance-visitors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/enhance-visitors/-/enhance-visitors-1.0.0.tgz",
-      "integrity": "sha1-qpRdBdpGVnKh69OP7i7T2oUY6Vo=",
-      "dev": true,
-      "requires": {
-        "lodash": "4.17.4"
       }
     },
     "enhanced-resolve": {
@@ -2782,72 +2693,92 @@
       }
     },
     "eslint": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
-      "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
-      "dev": true,
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.8.0.tgz",
+      "integrity": "sha1-Ip7w41Tg5h2DfHqA/fuoJeGZgV4=",
       "requires": {
+        "ajv": "5.2.3",
         "babel-code-frame": "6.22.0",
-        "chalk": "1.1.3",
-        "concat-stream": "1.5.2",
-        "debug": "2.6.8",
+        "chalk": "2.1.0",
+        "concat-stream": "1.6.0",
+        "cross-spawn": "5.1.0",
+        "debug": "3.1.0",
         "doctrine": "2.0.0",
-        "escope": "3.6.0",
-        "espree": "3.5.0",
+        "eslint-scope": "3.7.1",
+        "espree": "3.5.1",
         "esquery": "1.0.0",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "file-entry-cache": "2.0.0",
+        "functional-red-black-tree": "1.0.1",
         "glob": "7.1.2",
         "globals": "9.18.0",
-        "ignore": "3.3.3",
+        "ignore": "3.3.5",
         "imurmurhash": "0.1.4",
-        "inquirer": "0.12.0",
-        "is-my-json-valid": "2.16.0",
+        "inquirer": "3.3.0",
         "is-resolvable": "1.0.0",
-        "js-yaml": "3.7.0",
+        "js-yaml": "3.10.0",
         "json-stable-stringify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.4",
+        "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
         "natural-compare": "1.4.0",
         "optionator": "0.8.2",
         "path-is-inside": "1.0.2",
-        "pluralize": "1.2.1",
-        "progress": "1.1.8",
+        "pluralize": "7.0.0",
+        "progress": "2.0.0",
         "require-uncached": "1.0.3",
-        "shelljs": "0.7.8",
-        "strip-bom": "3.0.0",
+        "semver": "5.4.1",
+        "strip-ansi": "4.0.0",
         "strip-json-comments": "2.0.1",
-        "table": "3.8.3",
-        "text-table": "0.2.0",
-        "user-home": "2.0.0"
+        "table": "4.0.2",
+        "text-table": "0.2.0"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
+        "ajv": {
+          "version": "5.2.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+          "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "json-schema-traverse": "0.3.1",
+            "json-stable-stringify": "1.0.1"
           }
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "requires": {
+            "lru-cache": "4.1.1",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "esprima": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
         },
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -2857,250 +2788,53 @@
             "path-is-absolute": "1.0.1"
           }
         },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
+        "js-yaml": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "4.0.0"
+          }
         },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
         }
       }
     },
-    "eslint-config-xo": {
-      "version": "0.18.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-xo/-/eslint-config-xo-0.18.2.tgz",
-      "integrity": "sha1-ChVxIIdWGZKec1/9axhcQeihh68=",
-      "dev": true
-    },
-    "eslint-formatter-pretty": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-1.1.0.tgz",
-      "integrity": "sha1-q00G2gL+2ME66fDcVApDPvftb14=",
-      "dev": true,
+    "eslint-config-prettier": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-2.6.0.tgz",
+      "integrity": "sha1-8h2w67Q4rWePuYlGCXxLsZi+/Mw=",
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "chalk": "1.1.3",
-        "log-symbols": "1.0.2",
-        "plur": "2.1.2",
-        "string-width": "2.1.1"
+        "get-stdin": "5.0.1"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "log-symbols": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3"
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "3.0.0"
-              }
-            }
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
+        "get-stdin": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+          "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g="
         }
       }
     },
-    "eslint-import-resolver-node": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz",
-      "integrity": "sha512-yUtXS15gIcij68NmXmP9Ni77AQuCN0itXbCc/jWd8C6/yKZaSNXicpC8cgvjnxVdmfsosIXrjpzFq7GcDryb6A==",
-      "dev": true,
+    "eslint-scope": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
       "requires": {
-        "debug": "2.6.8",
-        "resolve": "1.4.0"
-      }
-    },
-    "eslint-module-utils": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
-      "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.8",
-        "pkg-dir": "1.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "pkg-dir": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2"
-          }
-        }
-      }
-    },
-    "eslint-plugin-ava": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-4.2.1.tgz",
-      "integrity": "sha1-fNtegbx3n0gz1HIKYJPl9KbKGRM=",
-      "dev": true,
-      "requires": {
-        "arrify": "1.0.1",
-        "deep-strict-equal": "0.2.0",
-        "enhance-visitors": "1.0.0",
-        "espree": "3.5.0",
-        "espurify": "1.7.0",
-        "import-modules": "1.1.0",
-        "multimatch": "2.1.0",
-        "pkg-up": "2.0.0"
-      }
-    },
-    "eslint-plugin-import": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz",
-      "integrity": "sha512-HGYmpU9f/zJaQiKNQOVfHUh2oLWW3STBrCgH0sHTX1xtsxYlH1zjLh8FlQGEIdZSdTbUMaV36WaZ6ImXkenGxQ==",
-      "dev": true,
-      "requires": {
-        "builtin-modules": "1.1.1",
-        "contains-path": "0.1.0",
-        "debug": "2.6.8",
-        "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "0.3.1",
-        "eslint-module-utils": "2.1.1",
-        "has": "1.0.1",
-        "lodash.cond": "4.5.2",
-        "minimatch": "3.0.4",
-        "read-pkg-up": "2.0.0"
-      },
-      "dependencies": {
-        "doctrine": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-          "dev": true,
-          "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
-          "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
-          }
-        }
-      }
-    },
-    "eslint-plugin-no-use-extend-native": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-no-use-extend-native/-/eslint-plugin-no-use-extend-native-0.3.12.tgz",
-      "integrity": "sha1-OtmgDC3yO11/f2vpFVCYWkq3Aeo=",
-      "dev": true,
-      "requires": {
-        "is-get-set-prop": "1.0.0",
-        "is-js-type": "2.0.0",
-        "is-obj-prop": "1.0.0",
-        "is-proto-prop": "1.0.0"
-      }
-    },
-    "eslint-plugin-promise": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.5.0.tgz",
-      "integrity": "sha1-ePu2/+BHIBYnVp6FpsU3OvKmj8o=",
-      "dev": true
-    },
-    "eslint-plugin-unicorn": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-2.1.2.tgz",
-      "integrity": "sha1-md/+n0dzsEvDk1an/r1k3XACdLw=",
-      "dev": true,
-      "requires": {
-        "import-modules": "1.1.0",
-        "lodash.camelcase": "4.3.0",
-        "lodash.kebabcase": "4.1.1",
-        "lodash.snakecase": "4.1.1",
-        "lodash.upperfirst": "4.3.1"
+        "esrecurse": "4.2.0",
+        "estraverse": "4.2.0"
       }
     },
     "espree": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
-      "integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
-      "dev": true,
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
+      "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
       "requires": {
         "acorn": "5.1.1",
         "acorn-jsx": "3.0.1"
@@ -3111,20 +2845,10 @@
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
       "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
     },
-    "espurify": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.7.0.tgz",
-      "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
-      "dev": true,
-      "requires": {
-        "core-js": "2.5.0"
-      }
-    },
     "esquery": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
-      "dev": true,
       "requires": {
         "estraverse": "4.2.0"
       }
@@ -3214,12 +2938,6 @@
         }
       }
     },
-    "exit-hook": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
-      "dev": true
-    },
     "expand-brackets": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
@@ -3296,6 +3014,16 @@
         "is-extendable": "0.1.1"
       }
     },
+    "external-editor": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
+      "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
+      "requires": {
+        "iconv-lite": "0.4.19",
+        "jschardet": "1.5.1",
+        "tmp": "0.0.33"
+      }
+    },
     "extglob": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
@@ -3324,8 +3052,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fastparse": {
       "version": "1.1.1",
@@ -3341,22 +3068,19 @@
       }
     },
     "figures": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-      "dev": true,
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.1"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "file-entry-cache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-      "dev": true,
       "requires": {
-        "flat-cache": "1.2.2",
+        "flat-cache": "1.3.0",
         "object-assign": "4.1.1"
       }
     },
@@ -3433,10 +3157,9 @@
       "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04="
     },
     "flat-cache": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
-      "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
-      "dev": true,
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "requires": {
         "circular-json": "0.3.3",
         "del": "2.2.2",
@@ -3448,7 +3171,6 @@
           "version": "2.2.2",
           "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
           "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-          "dev": true,
           "requires": {
             "globby": "5.0.0",
             "is-path-cwd": "1.0.0",
@@ -3463,7 +3185,6 @@
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -3477,7 +3198,6 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
           "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-          "dev": true,
           "requires": {
             "array-union": "1.0.2",
             "arrify": "1.0.1",
@@ -3490,8 +3210,7 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         }
       }
     },
@@ -4376,6 +4095,11 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
       "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E="
     },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+    },
     "gauge": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
@@ -4399,31 +4123,10 @@
         "globule": "1.2.0"
       }
     },
-    "generate-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-      "dev": true
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true,
-      "requires": {
-        "is-property": "1.0.2"
-      }
-    },
     "get-caller-file": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
-    },
-    "get-set-props": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/get-set-props/-/get-set-props-0.1.0.tgz",
-      "integrity": "sha1-mYR1wXhEVobQsyJG2l3428++jqM=",
-      "dev": true
     },
     "get-stdin": {
       "version": "4.0.1",
@@ -4880,6 +4583,11 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
       "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI="
     },
+    "iconv-lite": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+    },
     "icss-replace-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
@@ -4899,21 +4607,14 @@
       "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
     },
     "ignore": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
-      "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
-      "dev": true
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
+      "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw=="
     },
     "import-lazy": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
       "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
-    },
-    "import-modules": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/import-modules/-/import-modules-1.1.0.tgz",
-      "integrity": "sha1-dI23nFzEK7lwHvq0JPiU5yYA6dw=",
-      "dev": true
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -4963,50 +4664,52 @@
       "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
     },
     "inquirer": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-      "dev": true,
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "ansi-regex": "2.1.1",
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-width": "2.1.0",
-        "figures": "1.7.0",
+        "ansi-escapes": "3.0.0",
+        "chalk": "2.1.0",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "2.0.5",
+        "figures": "2.0.0",
         "lodash": "4.17.4",
-        "readline2": "1.0.1",
-        "run-async": "0.1.0",
-        "rx-lite": "3.1.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
+        "mute-stream": "0.0.7",
+        "run-async": "2.3.0",
+        "rx-lite": "4.0.8",
+        "rx-lite-aggregates": "4.0.8",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
         "through": "2.3.8"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
         }
       }
     },
@@ -5045,12 +4748,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz",
       "integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA="
-    },
-    "irregular-plurals": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.3.0.tgz",
-      "integrity": "sha512-njf5A+Mxb3kojuHd1DzISjjIl+XhyzovXEOyPPSzdQozq/Lf2tN27mOrAAsxEPZxpn6I4MGzs1oo9TxXxPFpaA==",
-      "dev": true
     },
     "is-absolute-url": {
       "version": "2.1.0",
@@ -5101,12 +4798,6 @@
         "is-primitive": "2.0.0"
       }
     },
-    "is-error": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-error/-/is-error-2.2.1.tgz",
-      "integrity": "sha1-aEqW2EB2V3yY9M20DG0mpRI78Zw=",
-      "dev": true
-    },
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -5133,43 +4824,12 @@
         "number-is-nan": "1.0.1"
       }
     },
-    "is-get-set-prop": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-get-set-prop/-/is-get-set-prop-1.0.0.tgz",
-      "integrity": "sha1-JzGHfk14pqae3M5rudaLB3nnYxI=",
-      "dev": true,
-      "requires": {
-        "get-set-props": "0.1.0",
-        "lowercase-keys": "1.0.0"
-      }
-    },
     "is-glob": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
       "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
       "requires": {
         "is-extglob": "2.1.1"
-      }
-    },
-    "is-js-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-js-type/-/is-js-type-2.0.0.tgz",
-      "integrity": "sha1-c2FwBtZZtOtHKbunR9KHgt8PfiI=",
-      "dev": true,
-      "requires": {
-        "js-types": "1.0.0"
-      }
-    },
-    "is-my-json-valid": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-      "dev": true,
-      "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
       }
     },
     "is-npm": {
@@ -5189,16 +4849,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
-    },
-    "is-obj-prop": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-obj-prop/-/is-obj-prop-1.0.0.tgz",
-      "integrity": "sha1-s03nnEULjXxzqyzfZ9yHWtuF+A4=",
-      "dev": true,
-      "requires": {
-        "lowercase-keys": "1.0.0",
-        "obj-props": "1.1.0"
-      }
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -5244,21 +4894,10 @@
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
     },
-    "is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "dev": true
-    },
-    "is-proto-prop": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-proto-prop/-/is-proto-prop-1.0.0.tgz",
-      "integrity": "sha1-s5UflcCJkk+11PzaZUKrPoPisiA=",
-      "dev": true,
-      "requires": {
-        "lowercase-keys": "1.0.0",
-        "proto-props": "0.2.1"
-      }
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
     "is-redirect": {
       "version": "1.0.0",
@@ -5269,7 +4908,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true,
       "requires": {
         "tryit": "1.0.3"
       }
@@ -5337,12 +4975,6 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
-    "js-types": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/js-types/-/js-types-1.0.0.tgz",
-      "integrity": "sha1-0kLmSU7Vcq08koCfyL7X92h8vwM=",
-      "dev": true
-    },
     "js-yaml": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
@@ -5357,6 +4989,11 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
+    },
+    "jschardet": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
+      "integrity": "sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A=="
     },
     "jsesc": {
       "version": "1.3.0",
@@ -5413,12 +5050,6 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
-    },
-    "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-      "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
@@ -5487,7 +5118,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
       "requires": {
         "prelude-ls": "1.1.2",
         "type-check": "0.3.2"
@@ -5560,22 +5190,10 @@
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
-    "lodash.cond": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
-      "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
-      "dev": true
-    },
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
-    },
-    "lodash.kebabcase": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
-      "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
-      "dev": true
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -5587,12 +5205,6 @@
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
       "integrity": "sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU="
     },
-    "lodash.snakecase": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
-      "integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40=",
-      "dev": true
-    },
     "lodash.tail": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
@@ -5602,12 +5214,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
-    },
-    "lodash.upperfirst": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
-      "integrity": "sha1-E2Xt9DFIBIHvDRxolXpe2Z1J984=",
-      "dev": true
     },
     "log-symbols": {
       "version": "2.0.0",
@@ -5906,23 +5512,10 @@
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
     },
-    "multimatch": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
-      "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-      "dev": true,
-      "requires": {
-        "array-differ": "1.0.0",
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "minimatch": "3.0.4"
-      }
-    },
     "mute-stream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
-      "dev": true
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
     "nan": {
       "version": "2.6.2",
@@ -5932,8 +5525,7 @@
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
     },
     "ncname": {
       "version": "1.0.0",
@@ -6190,12 +5782,6 @@
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
     },
-    "obj-props": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/obj-props/-/obj-props-1.1.0.tgz",
-      "integrity": "sha1-YmMT+qRCvv1KROmgLDy2vek3tRE=",
-      "dev": true
-    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -6247,10 +5833,12 @@
       }
     },
     "onetime": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-      "dev": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "requires": {
+        "mimic-fn": "1.1.0"
+      }
     },
     "opn": {
       "version": "4.0.2",
@@ -6265,7 +5853,6 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true,
       "requires": {
         "deep-is": "0.1.3",
         "fast-levenshtein": "2.0.6",
@@ -6278,8 +5865,7 @@
         "wordwrap": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-          "dev": true
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
         }
       }
     },
@@ -6611,16 +6197,6 @@
         "pinkie": "2.0.4"
       }
     },
-    "pkg-conf": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.0.0.tgz",
-      "integrity": "sha1-BxyHZQQDvM+5xif1h1G/5HwGcnk=",
-      "dev": true,
-      "requires": {
-        "find-up": "2.1.0",
-        "load-json-file": "2.0.0"
-      }
-    },
     "pkg-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
@@ -6629,29 +6205,10 @@
         "find-up": "2.1.0"
       }
     },
-    "pkg-up": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
-      "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
-      "dev": true,
-      "requires": {
-        "find-up": "2.1.0"
-      }
-    },
-    "plur": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
-      "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
-      "dev": true,
-      "requires": {
-        "irregular-plurals": "1.3.0"
-      }
-    },
     "pluralize": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
-      "dev": true
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
     },
     "portfinder": {
       "version": "1.0.13",
@@ -8273,8 +7830,7 @@
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "prepend-http": {
       "version": "1.0.4",
@@ -8285,6 +7841,11 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+    },
+    "prettier": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.7.2.tgz",
+      "integrity": "sha1-gTceZAGKr8ac8QMZVscOApM59U4="
     },
     "private": {
       "version": "0.1.7",
@@ -8302,16 +7863,9 @@
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
     "progress": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
-      "dev": true
-    },
-    "proto-props": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/proto-props/-/proto-props-0.2.1.tgz",
-      "integrity": "sha1-XgHcJnWg3pq/p255nfozTW9IP0s=",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
     },
     "proxy-addr": {
       "version": "1.1.5",
@@ -8558,17 +8112,6 @@
         "set-immediate-shim": "1.0.1"
       }
     },
-    "readline2": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-      "dev": true,
-      "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "mute-stream": "0.0.5"
-      }
-    },
     "recast": {
       "version": "0.11.23",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
@@ -8585,15 +8128,6 @@
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
           "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
         }
-      }
-    },
-    "rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true,
-      "requires": {
-        "resolve": "1.4.0"
       }
     },
     "redent": {
@@ -8794,18 +8328,9 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true,
       "requires": {
         "caller-path": "0.1.0",
         "resolve-from": "1.0.1"
-      },
-      "dependencies": {
-        "resolve-from": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-          "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
-          "dev": true
-        }
       }
     },
     "requires-port": {
@@ -8821,29 +8346,18 @@
         "path-parse": "1.0.5"
       }
     },
-    "resolve-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-1.0.0.tgz",
-      "integrity": "sha1-Tq7qQe0EDRcCRX32SkKysH0kb58=",
-      "dev": true,
-      "requires": {
-        "resolve-from": "2.0.0"
-      }
-    },
     "resolve-from": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
     },
     "restore-cursor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-      "dev": true,
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
       }
     },
     "right-align": {
@@ -8902,12 +8416,11 @@
       }
     },
     "run-async": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-      "dev": true,
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "requires": {
-        "once": "1.4.0"
+        "is-promise": "2.1.0"
       }
     },
     "run-parallel": {
@@ -8916,10 +8429,17 @@
       "integrity": "sha1-KQA8miFj4B4tLfyQV18sbB1hoDk="
     },
     "rx-lite": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
-      "dev": true
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "requires": {
+        "rx-lite": "4.0.8"
+      }
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -9149,33 +8669,6 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
-    "shelljs": {
-      "version": "0.7.8",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
-      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
-      "dev": true,
-      "requires": {
-        "glob": "7.1.2",
-        "interpret": "1.0.3",
-        "rechoir": "0.6.2"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        }
-      }
-    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -9187,10 +8680,19 @@
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
     },
     "slice-ansi": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        }
+      }
     },
     "slide": {
       "version": "1.1.6",
@@ -9515,82 +9017,55 @@
       }
     },
     "table": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
-      "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
-      "dev": true,
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "requires": {
-        "ajv": "4.11.8",
-        "ajv-keywords": "1.5.1",
-        "chalk": "1.1.3",
+        "ajv": "5.2.3",
+        "ajv-keywords": "2.1.0",
+        "chalk": "2.1.0",
         "lodash": "4.17.4",
-        "slice-ansi": "0.0.4",
+        "slice-ansi": "1.0.0",
         "string-width": "2.1.1"
       },
       "dependencies": {
-        "ajv-keywords": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-          "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
-          "dev": true
+        "ajv": {
+          "version": "5.2.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+          "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "json-schema-traverse": "0.3.1",
+            "json-stable-stringify": "1.0.1"
+          }
         },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
             "strip-ansi": "4.0.0"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "3.0.0"
-              }
-            }
           }
         },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
         }
       }
     },
@@ -9646,14 +9121,7 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "dev": true
-    },
-    "the-argv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/the-argv/-/the-argv-1.0.0.tgz",
-      "integrity": "sha1-AIRwUAVzDdhNt1UlPJMa45jblSI=",
-      "dev": true
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
     "through": {
       "version": "2.3.8",
@@ -9701,6 +9169,14 @@
         "setimmediate": "1.0.5"
       }
     },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "requires": {
+        "os-tmpdir": "1.0.2"
+      }
+    },
     "to-absolute-glob": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
@@ -9740,8 +9216,7 @@
     "tryit": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
-      "dev": true
+      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics="
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -9766,7 +9241,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
       "requires": {
         "prelude-ls": "1.1.2"
       }
@@ -9783,8 +9257,7 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "uglify-js": {
       "version": "3.0.27",
@@ -9985,15 +9458,6 @@
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "requires": {
         "prepend-http": "1.0.4"
-      }
-    },
-    "user-home": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "1.0.2"
       }
     },
     "util": {
@@ -10502,7 +9966,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true,
       "requires": {
         "mkdirp": "0.5.1"
       }
@@ -10517,44 +9980,6 @@
         "slide": "1.1.6"
       }
     },
-    "write-json-file": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.2.0.tgz",
-      "integrity": "sha1-UYYlBruzthnu+reFnx/WxtBTCHY=",
-      "dev": true,
-      "requires": {
-        "detect-indent": "5.0.0",
-        "graceful-fs": "4.1.11",
-        "make-dir": "1.0.0",
-        "pify": "2.3.0",
-        "sort-keys": "1.1.2",
-        "write-file-atomic": "2.1.0"
-      },
-      "dependencies": {
-        "detect-indent": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
-          "dev": true
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        }
-      }
-    },
-    "write-pkg": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-2.1.0.tgz",
-      "integrity": "sha1-NTqkTDnEjCFED1wIzmq9RhQcnAg=",
-      "dev": true,
-      "requires": {
-        "sort-keys": "1.1.2",
-        "write-json-file": "2.2.0"
-      }
-    },
     "xdg-basedir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
@@ -10564,109 +9989,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz",
       "integrity": "sha1-ZGV4SKIP/F31g6Qq2KJ3tFErvE0="
-    },
-    "xo": {
-      "version": "0.18.2",
-      "resolved": "https://registry.npmjs.org/xo/-/xo-0.18.2.tgz",
-      "integrity": "sha1-kqQusCpPsUnf6lUYAhkU9arIT/A=",
-      "dev": true,
-      "requires": {
-        "arrify": "1.0.1",
-        "debug": "2.6.8",
-        "deep-assign": "1.0.0",
-        "eslint": "3.19.0",
-        "eslint-config-xo": "0.18.2",
-        "eslint-formatter-pretty": "1.1.0",
-        "eslint-plugin-ava": "4.2.1",
-        "eslint-plugin-import": "2.7.0",
-        "eslint-plugin-no-use-extend-native": "0.3.12",
-        "eslint-plugin-promise": "3.5.0",
-        "eslint-plugin-unicorn": "2.1.2",
-        "get-stdin": "5.0.1",
-        "globby": "6.1.0",
-        "has-flag": "2.0.0",
-        "ignore": "3.3.3",
-        "lodash.isequal": "4.5.0",
-        "meow": "3.7.0",
-        "multimatch": "2.1.0",
-        "path-exists": "3.0.0",
-        "pkg-conf": "2.0.0",
-        "resolve-cwd": "1.0.0",
-        "resolve-from": "2.0.0",
-        "slash": "1.0.0",
-        "update-notifier": "2.2.0",
-        "xo-init": "0.5.0"
-      },
-      "dependencies": {
-        "get-stdin": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
-          "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
-          "dev": true
-        }
-      }
-    },
-    "xo-init": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xo-init/-/xo-init-0.5.0.tgz",
-      "integrity": "sha1-jijex5Z2zF4EL95f2PcQ4mRrDjY=",
-      "dev": true,
-      "requires": {
-        "arrify": "1.0.1",
-        "execa": "0.5.1",
-        "minimist": "1.2.0",
-        "path-exists": "3.0.0",
-        "read-pkg-up": "2.0.0",
-        "the-argv": "1.0.0",
-        "write-pkg": "2.1.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "4.1.1",
-            "which": "1.3.0"
-          }
-        },
-        "execa": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.5.1.tgz",
-          "integrity": "sha1-3j+4XLjW6RyFvLzrFkWBeFy1ezY=",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "4.0.2",
-            "get-stream": "2.3.1",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
-          "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
-          "dev": true,
-          "requires": {
-            "object-assign": "4.1.1",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
-          "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
-          }
-        }
-      }
     },
     "xregexp": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -6,13 +6,11 @@
   "license": "MIT",
   "contributors": [
     "Colin Gourlay <gourlay.colin@abc.net.au>",
-    "Nathan Hoad <hoad.nathan@abc.net.au>"
+    "Nathan Hoad <hoad.nathan@abc.net.au>",
+    "Simon Elvery <elvery.simon@abc.net.au>"
   ],
   "bin": {
     "aunty": "./src/bin/aunty.js"
-  },
-  "scripts": {
-    "test": "xo"
   },
   "engines": {
     "node": ">=7.6.0"
@@ -58,23 +56,8 @@
     "webpack-merge": "^4.1.0"
   },
   "devDependencies": {
-    "xo": "^0.18.2"
-  },
-  "xo": {
-    "rules": {
-      "eqeqeq": 0,
-      "import/no-dynamic-require": 0,
-      "import/no-unassigned-import": 0,
-      "no-await-in-loop": 0,
-      "no-eq-null": 0,
-      "no-multi-assign": 0,
-      "object-curly-spacing": 0,
-      "operator-linebreak": 0,
-      "unicorn/filename-case": 0
-    },
-    "ignores": [
-      "templates/**"
-    ],
-    "space": true
+    "eslint": "^4.8.0",
+    "eslint-config-prettier": "2.6.0",
+    "prettier": "1.7.2"
   }
 }

--- a/src/bin/aunty.js
+++ b/src/bin/aunty.js
@@ -26,7 +26,7 @@ let isGlobal;
 
 // Always prefer local CLI
 try {
-  cli = require(resolve.sync(`${name}/src/cli`, {basedir: process.cwd()})).cli;
+  cli = require(resolve.sync(`${name}/src/cli`, { basedir: process.cwd() })).cli;
 } catch (err) {
   isGlobal = true;
   cli = require('../cli').cli;

--- a/src/cli/constants.js
+++ b/src/cli/constants.js
@@ -5,17 +5,14 @@ const { cmd, dim, hvy, opt, req, sec } = require('../utils/color');
 const { indented, listPairs } = require('../utils/strings');
 
 module.exports.OPTIONS = {
-  boolean: [
-    'help',
-    'version'
-  ],
+  boolean: ['help', 'version'],
   alias: {
     help: 'h',
     version: 'v'
   }
 };
 
-const ALIASES = module.exports.ALIASES = {
+const ALIASES = (module.exports.ALIASES = {
   b: 'build',
   c: 'clean',
   d: 'deploy',
@@ -24,26 +21,17 @@ const ALIASES = module.exports.ALIASES = {
   n: 'new',
   r: 'release',
   s: 'serve'
-};
+});
 
 module.exports.COMMANDS = new Set(
-  []
-  .concat(Object.keys(ALIASES).map(key => ALIASES[key]))
-  .concat(Object.keys(ALIASES))
+  [].concat(Object.keys(ALIASES).map(key => ALIASES[key])).concat(Object.keys(ALIASES))
 );
 
 module.exports.DEFAULTS = {
   name: '__command__',
   options: {
-    boolean: [
-      'dry',
-      'force',
-      'help'
-    ],
-    string: [
-      'id',
-      'target'
-    ],
+    boolean: ['dry', 'force', 'help'],
+    string: ['id', 'target'],
     alias: {
       dry: 'd',
       id: 'i',
@@ -59,6 +47,7 @@ module.exports.MESSAGES = {
 ${cmd('aunty')} v${versionNumber}${isLocal ? dim(' (local)') : ''}`,
   unrecognised: commandName => `Unrecognised command: ${req(commandName)}`,
   usage: () => `${createLogo()}
+
 Usage: ${cmd('aunty')} ${req('<command>')} ${opt('[options]')} ${opt('[command_options]')}
 
 ${sec('Options')}

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -23,7 +23,7 @@ module.exports.cli = packs(async (args, isGlobal) => {
   const argv = minimist(args, OPTIONS);
 
   if (isGlobal) {
-    updateNotifier({pkg, updateCheckInterval: 36e5}).notify();
+    updateNotifier({ pkg, updateCheckInterval: 36e5 }).notify();
   }
 
   if (argv.version) {
@@ -33,9 +33,7 @@ module.exports.cli = packs(async (args, isGlobal) => {
   let commandName = argv._[0] || '';
   const isHelp = isArgHelpCommand(commandName);
 
-  if (!commandName || (isHelp && (
-    argv._.length === 1 || isArgHelpCommand(argv._[1])
-  ))) {
+  if (!commandName || (isHelp && (argv._.length === 1 || isArgHelpCommand(argv._[1])))) {
     return log(MESSAGES.usage());
   }
 
@@ -49,9 +47,7 @@ module.exports.cli = packs(async (args, isGlobal) => {
 
   commandName = ALIASES[commandName] || commandName;
 
-  const commandFn = require(
-    resolve(__dirname, `../commands/${commandName}`)
-  )[slugToCamel(commandName)];
+  const commandFn = require(resolve(__dirname, `../commands/${commandName}`))[slugToCamel(commandName)];
   const commandFnArgs = isHelp ? ['--help'] : args.slice(1);
 
   throws(await commandFn(commandFnArgs));
@@ -59,13 +55,7 @@ module.exports.cli = packs(async (args, isGlobal) => {
 
 let isEntryCommand;
 
-module.exports.command = ({
-  name,
-  options,
-  usage,
-  isProxy,
-  isConfigRequired
-}, fn) => {
+module.exports.command = ({ name, options, usage, isProxy, isConfigRequired }, fn) => {
   name = name || DEFAULTS.name;
   options = merge(options || {}, DEFAULTS.options);
   usage = usage || MESSAGES.usageFallback;

--- a/src/commands/build/constants.js
+++ b/src/commands/build/constants.js
@@ -11,9 +11,15 @@ Usage: ${cmd(`aunty ${name}`)} ${opt('[options]')}
 ${sec('Options')}
 
   ${opt('-d')}, ${opt('--dry')}                    Output the generated webpack configuration, then exit
-  ${opt('-c PATH')}, ${opt('--credentials=PATH')}  File where target credentials/config is held ${opt('[default: "~/.abc-credentials"]')}
-  ${opt('-i NAME')}, ${opt('--id=NAME')}           Id for this build (can be used to generate public root URL) ${opt(`[default: ${cmd('git branch')}]`)}
-  ${opt('-t NAME')}, ${opt('--target=NAME')}       Target to build for (can be used to generate public root URL) ${opt('[default: ------]')}
+  ${opt('-c PATH')}, ${opt('--credentials=PATH')}  File where target credentials/config is held ${opt(
+    '[default: "~/.abc-credentials"]'
+  )}
+  ${opt('-i NAME')}, ${opt('--id=NAME')}           Id for this build (can be used to generate public root URL) ${opt(
+    `[default: ${cmd('git branch')}]`
+  )}
+  ${opt('-t NAME')}, ${opt('--target=NAME')}       Target to build for (can be used to generate public root URL) ${opt(
+    '[default: ------]'
+  )}
 
   • If no ${opt('--target')} is specified, builds will assume the app will be available at the public root URL.
   • Builds will assume you have set ${cmd('NODE_ENV=production')}, unless you specify otherwise.

--- a/src/commands/build/index.js
+++ b/src/commands/build/index.js
@@ -10,45 +10,44 @@ const { dry, info, spin, warn } = require('../../utils/logging');
 const { clean } = require('../clean');
 const { MESSAGES } = require('./constants');
 
-module.exports.build = command({
-  name: 'build',
-  isConfigRequired: true,
-  usage: MESSAGES.usage
-}, async (argv, config) => {
-  if (!process.env.NODE_ENV) {
-    process.env.NODE_ENV = 'production';
+module.exports.build = command(
+  {
+    name: 'build',
+    isConfigRequired: true,
+    usage: MESSAGES.usage
+  },
+  async (argv, config) => {
+    if (!process.env.NODE_ENV) {
+      process.env.NODE_ENV = 'production';
+    }
+
+    const webpackConfig = createConfig(argv, config);
+
+    if (argv.dry) {
+      return dry({
+        'Webpack config': webpackConfig
+      });
+    }
+
+    info(MESSAGES.build(process.env.NODE_ENV, argv.target, webpackConfig.output.publicPath));
+
+    throws(await clean());
+
+    const spinner = spin('Build');
+    const compiler = webpack(webpackConfig);
+    const stats = unpack(await packs(pify(compiler.run.bind(compiler)))());
+
+    if (stats.hasErrors()) {
+      spinner.fail();
+
+      throw stats.toJson({}, true).errors[0];
+    }
+
+    if (stats.hasWarnings()) {
+      spinner.warn();
+      stats.toJson({}, true).warnings.forEach(warn);
+    } else {
+      spinner.succeed();
+    }
   }
-
-  const webpackConfig = createConfig(argv, config);
-
-  if (argv.dry) {
-    return dry({
-      'Webpack config': webpackConfig
-    });
-  }
-
-  info(MESSAGES.build(
-    process.env.NODE_ENV,
-    argv.target,
-    webpackConfig.output.publicPath
-  ));
-
-  throws(await clean());
-
-  const spinner = spin('Build');
-  const compiler = webpack(webpackConfig);
-  const stats = unpack(await packs(pify(compiler.run.bind(compiler)))());
-
-  if (stats.hasErrors()) {
-    spinner.fail();
-
-    throw stats.toJson({}, true).errors[0];
-  }
-
-  if (stats.hasWarnings()) {
-    spinner.warn();
-    stats.toJson({}, true).warnings.forEach(warn);
-  } else {
-    spinner.succeed();
-  }
-});
+);

--- a/src/commands/clean/constants.js
+++ b/src/commands/clean/constants.js
@@ -5,7 +5,9 @@ const { bulleted, styleLastSegment } = require('../../utils/strings');
 
 module.exports.MESSAGES = {
   deletion: paths =>
-    paths.length < 1 ? `Nothing to delete` : `Deleted:
+    paths.length < 1
+      ? `Nothing to delete`
+      : `Deleted:
 ${bulleted(paths.map(path => styleLastSegment(path, ok)))}`,
   usage: name => `
 Usage: ${cmd(`aunty ${name}`)} ${opt(`[${req('glob(s)')}]`)}

--- a/src/commands/clean/index.js
+++ b/src/commands/clean/index.js
@@ -7,27 +7,30 @@ const { BUILD_DIR } = require('../../projects/constants');
 const { dry, spin } = require('../../utils/logging');
 const { MESSAGES } = require('./constants');
 
-module.exports.clean = command({
-  name: 'clean',
-  usage: MESSAGES.usage,
-  isConfigRequired: true
-}, async (argv, config) => {
-  const cwd = config.root;
-  let globs = argv._.length ? argv._ : config.clean;
+module.exports.clean = command(
+  {
+    name: 'clean',
+    usage: MESSAGES.usage,
+    isConfigRequired: true
+  },
+  async (argv, config) => {
+    const cwd = config.root;
+    let globs = argv._.length ? argv._ : config.clean;
 
-  if (!Array.isArray(globs) && typeof globs !== 'string') {
-    globs = [BUILD_DIR];
+    if (!Array.isArray(globs) && typeof globs !== 'string') {
+      globs = [BUILD_DIR];
+    }
+
+    if (argv.dry) {
+      return dry({
+        'Deletion paths': { globs, cwd }
+      });
+    }
+
+    const spinner = spin('Clean');
+
+    await del(globs, { cwd });
+
+    spinner.succeed();
   }
-
-  if (argv.dry) {
-    return dry({
-      'Deletion paths': {globs, cwd}
-    });
-  }
-
-  const spinner = spin('Clean');
-
-  await del(globs, {cwd});
-
-  spinner.succeed();
-});
+);

--- a/src/commands/deploy/constants.js
+++ b/src/commands/deploy/constants.js
@@ -7,7 +7,7 @@ const { styleLastSegment } = require('../../utils/strings');
 
 module.exports.REQUIRED_PROPERTIES = ['from', 'to', 'type', 'username', 'password', 'host'];
 
-const VALID_TYPES = module.exports.VALID_TYPES = new Set(['ftp', 'ssh']);
+const VALID_TYPES = (module.exports.VALID_TYPES = new Set(['ftp', 'ssh']));
 
 module.exports.DEFAULTS = {
   RSYNC: {
@@ -20,48 +20,46 @@ module.exports.DEFAULTS = {
 };
 
 module.exports.OPTIONS = {
-  boolean: [
-    'shouldRespectTargetSymlinks'
-  ],
-  string: [
-    'credentials'
-  ],
+  boolean: ['shouldRespectTargetSymlinks'],
+  string: ['credentials'],
   alias: {
     credentials: 'c'
   },
   default: {
-    credentials: join(
-      (process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE),
-      '.abc-credentials'
-    )
+    credentials: join(process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE, '.abc-credentials')
   }
 };
 
 module.exports.MESSAGES = {
   NO_TARGETS: 'There are no targets to deploy to.',
   NO_MAPPABLE_ID: 'Could not create symlink because target path does not contain a mappable id.',
-  sourceIsNotDirectory: from =>
-    `${hvy(from)} is not a directory.`,
-  targetDoesNotExist: key =>
-    `The target ${hvy(key)} doesn't exist in the project configuration`,
+  sourceIsNotDirectory: from => `${hvy(from)} is not a directory.`,
+  targetDoesNotExist: key => `The target ${hvy(key)} doesn't exist in the project configuration`,
   targetNotConfigured: (key, prop) =>
     `The target ${hvy(key)} in your configuration is incomplete or has incomplete credentials. Missing: ${hvy(prop)}`,
   unrecognisedType: (key, type) =>
-    `The target ${hvy(key)} has ${type ? 'an unrecognised' : 'no'} deployment type${type ? `: ${hvy(type)}` : ''}. Acceptable types are: ${Array.from(VALID_TYPES).map(x => hvy(x)).join(', ')}`,
+    `The target ${hvy(key)} has ${type ? 'an unrecognised' : 'no'} deployment type${type
+      ? `: ${hvy(type)}`
+      : ''}. Acceptable types are: ${Array.from(VALID_TYPES)
+      .map(x => hvy(x))
+      .join(', ')}`,
   deployment: (type, from, to, host) => `Deployment (${hvy(type)}):
   ┣ ${hvy('from')} ${styleLastSegment(from, req)}
   ┣ ${hvy('to')}   ${styleLastSegment(to, req)}
   ┗ ${hvy('on')}   ${req(host)}`,
-  publicURL: url =>
-    `Public URL: ${hvy(url)}`,
+  publicURL: url => `Public URL: ${hvy(url)}`,
   usage: name => `
 Usage: ${cmd(`aunty ${name}`)} ${opt('[options]')}
 
 ${sec('Options')}
 
   ${opt('-d')}, ${opt('--dry')}                    Output the deployment target(s) configuration, then exit
-  ${opt('-c PATH')}, ${opt('--credentials=PATH')}  File where target credentials/config is held ${opt('[default: "~/.abc-credentials"]')}
-  ${opt('-i NAME')}, ${opt('--id=NAME')}           Id for this deployment (can be used in destination path) ${opt(`[default: ${cmd('git branch')}]`)}
+  ${opt('-c PATH')}, ${opt('--credentials=PATH')}  File where target credentials/config is held ${opt(
+    '[default: "~/.abc-credentials"]'
+  )}
+  ${opt('-i NAME')}, ${opt('--id=NAME')}           Id for this deployment (can be used in destination path) ${opt(
+    `[default: ${cmd('git branch')}]`
+  )}
   ${opt('-t NAME')}, ${opt('--target=NAME')}       Target to deploy to ${opt('[default: ---]')}
 
 ${sec(`Example ${hvy('aunty')} config`)}:

--- a/src/commands/deploy/index.js
+++ b/src/commands/deploy/index.js
@@ -40,20 +40,16 @@ const ftp = packs(target => {
 });
 
 const rsync = packs(target => {
-  return pify(rsyncwrapper)(Object.assign(
-    {},
-    DEFAULTS.RSYNC,
-    {
-      src: `${target.from}/${Array.isArray(target.files) ?
-        target.files[0] : target.files}`,
+  return pify(rsyncwrapper)(
+    Object.assign({}, DEFAULTS.RSYNC, {
+      src: `${target.from}/${Array.isArray(target.files) ? target.files[0] : target.files}`,
       dest: `${target.username}@${target.host}:${target.to}`
-    }
-  ));
+    })
+  );
 });
 
 const symlink = packs(async target => {
-  const symlinkName = typeof target.symlink === 'string' ?
-    target.symlink : DEFAULTS.SYMLINK.NAME;
+  const symlinkName = typeof target.symlink === 'string' ? target.symlink : DEFAULTS.SYMLINK.NAME;
   const symlinkPath = target.to.replace(target.id, symlinkName);
 
   if (symlinkPath === target.to) {
@@ -67,9 +63,7 @@ const symlink = packs(async target => {
 
   await pify(ssh.on)('ready');
 
-  const stream = await pify(ssh.exec)(
-    `rm -rf ${symlinkPath} && ln -s ${target.to} ${symlinkPath}`
-  );
+  const stream = await pify(ssh.exec)(`rm -rf ${symlinkPath} && ln -s ${target.to} ${symlinkPath}`);
 
   await pify(stream.on)('exit');
 
@@ -104,78 +98,87 @@ const deployToServer = packs(async target => {
   }
 });
 
-module.exports.deploy = command({
-  name: 'deploy',
-  options: OPTIONS,
-  usage: MESSAGES.usage,
-  isConfigRequired: true
-}, async (argv, config) => {
-  // 1) Get known/specified deployment target(s)
+module.exports.deploy = command(
+  {
+    name: 'deploy',
+    options: OPTIONS,
+    usage: MESSAGES.usage,
+    isConfigRequired: true
+  },
+  async (argv, config) => {
+    // 1) Get known/specified deployment target(s)
 
-  let keys = Object.keys(config.deploy);
+    let keys = Object.keys(config.deploy);
 
-  if (argv.target) {
-    keys = keys.filter(key => key === argv.target);
+    if (argv.target) {
+      keys = keys.filter(key => key === argv.target);
+
+      if (keys.length < 1) {
+        throw MESSAGES.targetDoesNotExist(argv.target);
+      }
+    }
 
     if (keys.length < 1) {
-      throw MESSAGES.targetDoesNotExist(argv.target);
-    }
-  }
-
-  if (keys.length < 1) {
-    throw MESSAGES.NO_TARGETS;
-  }
-
-  // 2) Create an array of config objects for each target we know about
-
-  const credentials = unpack(await getJSON(argv.credentials));
-
-  const targets = keys.map(key => Object.assign(
-    {
-      __key__: key,
-      id: config.id,
-      name: config.name,
-      files: '**'
-    },
-    credentials[key],
-    config.deploy[key],
-    (argv.shouldRespectTargetSymlinks ? {} : {symlink: null})
-  ));
-
-  // 3) Validate & normalise those configs (in parallel)
-
-  await Promise.all(targets.map(async target => {
-    // 3.1) Check 'type' is valid
-    if (!VALID_TYPES.has(target.type)) {
-      throw MESSAGES.unrecognisedType(target.__key__, target.type);
+      throw MESSAGES.NO_TARGETS;
     }
 
-    // 3.2) Check all properties are present
-    REQUIRED_PROPERTIES.forEach(prop => {
-      if (target[prop] == null) {
-        throw MESSAGES.targetNotConfigured(target.__key__, prop);
-      }
-    });
+    // 2) Create an array of config objects for each target we know about
 
-    // 3.3) Check 'from' directory exists
-    if (!existsSync(target.from) || !statSync(target.from).isDirectory()) {
-      throw (MESSAGES.sourceIsNotDirectory(target.from));
+    const credentials = unpack(await getJSON(argv.credentials));
+
+    const targets = keys.map(key =>
+      Object.assign(
+        {
+          __key__: key,
+          id: config.id,
+          name: config.name,
+          files: '**'
+        },
+        credentials[key],
+        config.deploy[key],
+        argv.shouldRespectTargetSymlinks ? {} : { symlink: null }
+      )
+    );
+
+    // 3) Validate & normalise those configs (in parallel)
+
+    await Promise.all(
+      targets.map(async target => {
+        // 3.1) Check 'type' is valid
+        if (!VALID_TYPES.has(target.type)) {
+          throw MESSAGES.unrecognisedType(target.__key__, target.type);
+        }
+
+        // 3.2) Check all properties are present
+        REQUIRED_PROPERTIES.forEach(prop => {
+          if (target[prop] == null) {
+            throw MESSAGES.targetNotConfigured(target.__key__, prop);
+          }
+        });
+
+        // 3.3) Check 'from' directory exists
+        if (!existsSync(target.from) || !statSync(target.from).isDirectory()) {
+          throw MESSAGES.sourceIsNotDirectory(target.from);
+        }
+
+        // 3.4) Remove temporary properties
+        delete target._from;
+        delete target._to;
+      })
+    );
+
+    if (argv.dry) {
+      return dry(
+        targets.reduce((memo, target) => {
+          memo[`Deployment to ${target.__key__}`] = target;
+
+          return memo;
+        }, {})
+      );
     }
 
-    // 3.4) Remove temporary properties
-    delete target._from;
-    delete target._to;
-  }));
-
-  if (argv.dry) {
-    return dry(targets.reduce((memo, target) => {
-      memo[`Deployment to ${target.__key__}`] = target;
-
-      return memo;
-    }, {}));
+    for (const target of targets) {
+      throws(await deployToServer(target));
+    }
   }
-
-  for (const target of targets) {
-    throws(await deployToServer(target));
-  }
-});
+);

--- a/src/commands/init/index.js
+++ b/src/commands/init/index.js
@@ -7,13 +7,17 @@ const { throws } = require('../../utils/async');
 const { new: _new } = require('../new');
 const { MESSAGES } = require('./constants');
 
-module.exports.init = command({
-  name: 'init',
-  usage: MESSAGES.usage
-}, async argv => {
-  const args = argv.$.slice(0, 1)
-    .concat(['.', `--name=${basename(process.cwd())}`])
-    .concat(argv.$.slice(1));
+module.exports.init = command(
+  {
+    name: 'init',
+    usage: MESSAGES.usage
+  },
+  async argv => {
+    const args = argv.$
+      .slice(0, 1)
+      .concat(['.', `--name=${basename(process.cwd())}`])
+      .concat(argv.$.slice(1));
 
-  throws(await _new(args));
-});
+    throws(await _new(args));
+  }
+);

--- a/src/commands/new/constants.js
+++ b/src/commands/new/constants.js
@@ -11,13 +11,11 @@ module.exports.DEFAULT_TEMPLATE_VARS = {
   auntyVersion: [MAJOR, MINOR, 'x'].join('.'),
   authorName: 'ABC News',
   buildDir: BUILD_DIR,
-  currentYear: (new Date()).getFullYear()
+  currentYear: new Date().getFullYear()
 };
 
 module.exports.OPTIONS = {
-  string: [
-    'name'
-  ],
+  string: ['name'],
   alias: {
     name: 'n'
   }

--- a/src/commands/release/constants.js
+++ b/src/commands/release/constants.js
@@ -4,9 +4,7 @@ const { cmd, hvy, opt, sec } = require('../../utils/color');
 const FORCE_REMINDER = `Use the ${opt('--force')} option to ignore warnings or release without tagging.`;
 
 module.exports.OPTIONS = {
-  string: [
-    'git-remote'
-  ],
+  string: ['git-remote'],
   default: {
     'git-remote': 'origin'
   }
@@ -17,8 +15,9 @@ module.exports.MESSAGES = {
   NOT_REPO: `You can't tag a release or deploy using a tag name becase this project isn't a git repo.`,
   HAS_CHANGES: `You shouldn't release builds which may contain un-committed changes! ${FORCE_REMINDER}`,
   hasTag: (tag, isTagOnHead) =>
-    `The tag ${hvy(tag)} already exists${isTagOnHead ? '' :
-      ` and your current HEAD doesn't point to it`}! ${FORCE_REMINDER}`,
+    `The tag ${hvy(tag)} already exists${isTagOnHead
+      ? ''
+      : ` and your current HEAD doesn't point to it`}! ${FORCE_REMINDER}`,
   createTag: tag => `Create tag ${hvy(tag)}`,
   pushTag: (tag, remote) => `Push tag ${hvy(tag)} to remote ${hvy(remote)}`,
   usage: name => `

--- a/src/commands/release/index.js
+++ b/src/commands/release/index.js
@@ -1,77 +1,80 @@
 // Ours
 const { command } = require('../../cli');
 const { throws } = require('../../utils/async');
-const {
-  createTag, getCurrentTags, getRemotes, hasChanges, hasTag, isRepo, pushTag
-} = require('../../utils/git');
+const { createTag, getCurrentTags, getRemotes, hasChanges, hasTag, isRepo, pushTag } = require('../../utils/git');
 const { dry, spin } = require('../../utils/logging');
 const { build } = require('../build');
 const { deploy } = require('../deploy');
 const { MESSAGES: DEPLOY_MESSAGES } = require('../deploy/constants');
 const { MESSAGES, OPTIONS } = require('./constants');
 
-module.exports.release = command({
-  name: 'release',
-  options: OPTIONS,
-  usage: MESSAGES.usage,
-  isConfigRequired: true
-}, async (argv, config) => {
-  const id = config.version;
-  let spinner;
+module.exports.release = command(
+  {
+    name: 'release',
+    options: OPTIONS,
+    usage: MESSAGES.usage,
+    isConfigRequired: true
+  },
+  async (argv, config) => {
+    const id = config.version;
+    let spinner;
 
-  if (argv.dry) {
-    return dry({
-      'Release version': id
-    });
-  }
-
-  // 1) Ensure the project is a git repo
-
-  if (!(await isRepo())) {
-    throw MESSAGES.NOT_REPO;
-  }
-
-  // 2) Ensure the project has a deployment config
-
-  if (typeof config.deploy !== 'object') {
-    throw DEPLOY_MESSAGES.NO_TARGETS;
-  }
-
-  // 3) Ensure the project no un-committed changes (skippable)
-
-  if (!argv.force && await hasChanges()) {
-    throw MESSAGES.HAS_CHANGES;
-  }
-
-  // 4) Tag a new release (skippable)
-
-  if (!argv.force) {
-    if (await hasTag(id)) {
-      throw MESSAGES.hasTag(id, (await getCurrentTags()).has(id));
+    if (argv.dry) {
+      return dry({
+        'Release version': id
+      });
     }
 
-    spinner = spin(MESSAGES.createTag(id));
-    await createTag(id);
-    spinner.succeed();
+    // 1) Ensure the project is a git repo
 
-    const remotes = await getRemotes();
-    const remote = argv['git-remote'];
+    if (!await isRepo()) {
+      throw MESSAGES.NOT_REPO;
+    }
 
-    if (remotes.has(remote)) {
-      spinner = spin(MESSAGES.pushTag(id, remote));
-      await pushTag(remote, id);
+    // 2) Ensure the project has a deployment config
+
+    if (typeof config.deploy !== 'object') {
+      throw DEPLOY_MESSAGES.NO_TARGETS;
+    }
+
+    // 3) Ensure the project no un-committed changes (skippable)
+
+    if (!argv.force && (await hasChanges())) {
+      throw MESSAGES.HAS_CHANGES;
+    }
+
+    // 4) Tag a new release (skippable)
+
+    if (!argv.force) {
+      if (await hasTag(id)) {
+        throw MESSAGES.hasTag(id, (await getCurrentTags()).has(id));
+      }
+
+      spinner = spin(MESSAGES.createTag(id));
+      await createTag(id);
       spinner.succeed();
+
+      const remotes = await getRemotes();
+      const remote = argv['git-remote'];
+
+      if (remotes.has(remote)) {
+        spinner = spin(MESSAGES.pushTag(id, remote));
+        await pushTag(remote, id);
+        spinner.succeed();
+      }
     }
+
+    // 4) For each target, build the project and deploy it
+
+    const targets = argv.target ? [argv.target] : Object.keys(config.deploy);
+
+    await Promise.all(
+      targets.map(async target => {
+        const args = ['--id', id, '--target', target];
+
+        throws(await build(args));
+        throws(await deploy(args.concat(['--shouldRespectTargetSymlinks'])));
+      })
+    );
   }
-
-  // 4) For each target, build the project and deploy it
-
-  const targets = argv.target ? [argv.target] : Object.keys(config.deploy);
-
-  await Promise.all(targets.map(async target => {
-    const args = ['--id', id, '--target', target];
-
-    throws(await build(args));
-    throws(await deploy(args.concat(['--shouldRespectTargetSymlinks'])));
-  }));
-});
+);

--- a/src/commands/serve/constants.js
+++ b/src/commands/serve/constants.js
@@ -3,11 +3,7 @@ const { cmd, opt, sec } = require('../../utils/color');
 const { DEV_SERVER_PORT } = require('../../projects/constants');
 
 module.exports.OPTIONS = {
-  string: [
-    'host',
-    'hot',
-    'port'
-  ]
+  string: ['host', 'hot', 'port']
 };
 
 module.exports.MESSAGES = {

--- a/src/commands/serve/index.js
+++ b/src/commands/serve/index.js
@@ -12,49 +12,47 @@ const { MESSAGES: BUILD_MESSAGES } = require('../build/constants');
 const { clean } = require('../clean');
 const { MESSAGES, OPTIONS } = require('./constants');
 
-module.exports.serve = command({
-  name: 'serve',
-  options: OPTIONS,
-  usage: MESSAGES.usage,
-  isConfigRequired: true
-}, async (argv, config) => {
-  if (!process.env.NODE_ENV) {
-    process.env.NODE_ENV = 'development';
-  }
+module.exports.serve = command(
+  {
+    name: 'serve',
+    options: OPTIONS,
+    usage: MESSAGES.usage,
+    isConfigRequired: true
+  },
+  async (argv, config) => {
+    if (!process.env.NODE_ENV) {
+      process.env.NODE_ENV = 'development';
+    }
 
-  const [webpackConfig, devServerConfig] = createConfig(argv, config, true);
+    const [webpackConfig, devServerConfig] = createConfig(argv, config, true);
 
-  const { port } = devServerConfig;
+    const { port } = devServerConfig;
 
-  delete devServerConfig.host;
-  delete devServerConfig.port;
+    delete devServerConfig.host;
+    delete devServerConfig.port;
 
-  if (argv.dry) {
-    return dry({
-      'Webpack config': webpackConfig,
-      'Dev server config': devServerConfig
+    if (argv.dry) {
+      return dry({
+        'Webpack config': webpackConfig,
+        'Dev server config': devServerConfig
+      });
+    }
+
+    info(BUILD_MESSAGES.build(process.env.NODE_ENV, argv.target, webpackConfig.output.publicPath));
+
+    throws(await clean());
+
+    const spinner = spin(`Serve${devServerConfig.hot ? ` (${cmd('hot')})` : ''}`);
+    const compiler = webpack(webpackConfig);
+    const server = new WebpackDevServer(compiler, devServerConfig);
+
+    return new Promise((resolve, reject) => {
+      server.listen(port, '0.0.0.0', err => {
+        if (err) {
+          spinner.fail();
+          reject(err);
+        }
+      });
     });
   }
-
-  info(BUILD_MESSAGES.build(
-    process.env.NODE_ENV,
-    argv.target,
-    webpackConfig.output.publicPath
-  ));
-
-  throws(await clean());
-
-  const spinner = spin(`Serve${devServerConfig.hot ? ` (${cmd('hot')})` : ''}`);
-  const compiler = webpack(webpackConfig);
-  const server = new WebpackDevServer(compiler, devServerConfig);
-
-  return new Promise((resolve, reject) => {
-    server.listen(port, '0.0.0.0', err => {
-      if (err) {
-        spinner.fail();
-        reject(err);
-      }
-    });
-  });
-});
-
+);

--- a/src/projects/config.js
+++ b/src/projects/config.js
@@ -20,8 +20,7 @@ let config;
 function resolveDeployConfig(config) {
   config.deploy = config.deploy || DEFAULTS.deploy;
 
-  Object.keys(config.deploy)
-  .forEach(key => {
+  Object.keys(config.deploy).forEach(key => {
     const target = config.deploy[key];
 
     if (!target._from) {
@@ -34,10 +33,9 @@ function resolveDeployConfig(config) {
 
     target.from = `${config.root}/${target._from}`;
     target.to = target._to.replace('<name>', config.name).replace('<id>', config.id);
-    target.publicURL = KNOWN_TARGETS[key] ? target.to.replace(
-      KNOWN_TARGETS[key].publicPathRewritePattern,
-      `${KNOWN_TARGETS[key].publicURLRoot}$1/`
-    ) : null;
+    target.publicURL = KNOWN_TARGETS[key]
+      ? target.to.replace(KNOWN_TARGETS[key].publicPathRewritePattern, `${KNOWN_TARGETS[key].publicURLRoot}$1/`)
+      : null;
   });
 
   return config;
@@ -49,7 +47,7 @@ module.exports.getConfig = packs(async argv => {
   }
 
   if (root === null) {
-    throw (MESSAGES.NOT_PACKAGE);
+    throw MESSAGES.NOT_PACKAGE;
   }
 
   if (!pkg) {
@@ -67,17 +65,25 @@ module.exports.getConfig = packs(async argv => {
     let auntyConfig = configFileConfig || pkg.aunty || {};
 
     if (typeof auntyConfig === 'string') {
-      auntyConfig = {type: auntyConfig};
+      auntyConfig = { type: auntyConfig };
     }
 
-    config = Object.assign({
-      name: pkg.name,
-      version: pkg.version,
-      root
-    }, auntyConfig);
+    config = Object.assign(
+      {
+        name: pkg.name,
+        version: pkg.version,
+        root
+      },
+      auntyConfig
+    );
   }
 
-  return resolveDeployConfig(Object.assign({
-    id: argv.id || (await isRepo() && await getCurrentLabel()) || 'default'
-  }, config));
+  return resolveDeployConfig(
+    Object.assign(
+      {
+        id: argv.id || ((await isRepo()) && (await getCurrentLabel())) || 'default'
+      },
+      config
+    )
+  );
 });

--- a/src/projects/constants.js
+++ b/src/projects/constants.js
@@ -3,15 +3,11 @@ const { hvy } = require('../utils/color');
 
 module.exports.CONFIG_FILE_NAME = 'aunty.config.js';
 
-const BASIC_APP = module.exports.BASIC_APP = 'basic-app';
-const PREACT_APP = module.exports.PREACT_APP = 'preact-app';
-const REACT_APP = module.exports.REACT_APP = 'react-app';
+const BASIC_APP = (module.exports.BASIC_APP = 'basic-app');
+const PREACT_APP = (module.exports.PREACT_APP = 'preact-app');
+const REACT_APP = (module.exports.REACT_APP = 'react-app');
 
-module.exports.PROJECT_TYPES = new Set([
-  BASIC_APP,
-  PREACT_APP,
-  REACT_APP
-]);
+module.exports.PROJECT_TYPES = new Set([BASIC_APP, PREACT_APP, REACT_APP]);
 
 module.exports.PROJECT_TYPE_DESCRIPTIONS = {
   [BASIC_APP]: 'a vanilla JS app.',
@@ -19,7 +15,7 @@ module.exports.PROJECT_TYPE_DESCRIPTIONS = {
   [REACT_APP]: 'a React-enabled app.'
 };
 
-const BUILD_DIR = module.exports.BUILD_DIR = 'build';
+const BUILD_DIR = (module.exports.BUILD_DIR = 'build');
 
 module.exports.DEV_SERVER_PORT = 8000;
 

--- a/src/projects/preact-app/index.js
+++ b/src/projects/preact-app/index.js
@@ -1,7 +1,4 @@
-module.exports.dependencies = [
-  'preact',
-  'preact-compat'
-];
+module.exports.dependencies = ['preact', 'preact-compat'];
 
 module.exports.babel = {
   presets: [

--- a/src/projects/react-app/index.js
+++ b/src/projects/react-app/index.js
@@ -1,12 +1,7 @@
-module.exports.dependencies = [
-  'react',
-  'react-dom'
-];
+module.exports.dependencies = ['react', 'react-dom'];
 
 module.exports.babel = {
-  presets: [
-    require.resolve('babel-preset-react')
-  ]
+  presets: [require.resolve('babel-preset-react')]
 };
 
 module.exports.webpack = {};

--- a/src/projects/webpack.js
+++ b/src/projects/webpack.js
@@ -41,12 +41,8 @@ module.exports.createConfig = (argv, config, isServer) => {
 
   let babelOptions = merge(
     {
-      presets: [
-        require.resolve('babel-preset-es2015')
-      ],
-      plugins: [
-        require.resolve('babel-plugin-transform-object-rest-spread')
-      ],
+      presets: [require.resolve('babel-preset-es2015')],
+      plugins: [require.resolve('babel-plugin-transform-object-rest-spread')],
       cacheDirectory: true
     },
     projectTypeConfig.babel || {}
@@ -73,9 +69,7 @@ module.exports.createConfig = (argv, config, isServer) => {
         rules: [
           {
             test: /\.js$/,
-            include: [
-              path.resolve(config.root, buildConfig.from)
-            ],
+            include: [path.resolve(config.root, buildConfig.from)],
             loader: require.resolve('babel-loader'),
             options: babelOptions
           },
@@ -91,9 +85,7 @@ module.exports.createConfig = (argv, config, isServer) => {
                   camelCase: true,
                   localIdentName: isProd
                     ? '[hash:base64:5]'
-                    : buildConfig.useCSSModules
-                      ? '[name]__[local]--[hash:base64:5]'
-                      : '[local]',
+                    : buildConfig.useCSSModules ? '[name]__[local]--[hash:base64:5]' : '[local]',
                   minimize: isProd,
                   modules: buildConfig.useCSSModules,
                   sourcemaps: !isProd
@@ -161,9 +153,11 @@ module.exports.createConfig = (argv, config, isServer) => {
           }
         }),
         new webpack.EnvironmentPlugin(Object.keys(process.env)),
-        new CopyPlugin([{
-          from: `${config.root}/public`
-        }])
+        new CopyPlugin([
+          {
+            from: `${config.root}/public`
+          }
+        ])
       ]
     },
     projectTypeConfig.webpack || {}
@@ -226,10 +220,7 @@ module.exports.createConfig = (argv, config, isServer) => {
   webpackConfig.output.publicPath = devServerConfig.publicPath = `http://${devServerConfig.host}:${devServerConfig.port}/`;
 
   if (devServerConfig.hot) {
-    webpackConfig.entry = upgradeEntryToHot(
-      webpackConfig.entry,
-      webpackConfig.output.publicPath
-    );
+    webpackConfig.entry = upgradeEntryToHot(webpackConfig.entry, webpackConfig.output.publicPath);
     webpackConfig.plugins.push(new webpack.HotModuleReplacementPlugin());
   }
 
@@ -237,10 +228,7 @@ module.exports.createConfig = (argv, config, isServer) => {
 };
 
 function upgradeEntryToHot(entry, publicPath) {
-  const heat = [
-    `webpack-dev-server/client?${publicPath}`,
-    'webpack/hot/dev-server'
-  ];
+  const heat = [`webpack-dev-server/client?${publicPath}`, 'webpack/hot/dev-server'];
 
   if (Array.isArray(entry) || typeof entry === 'string') {
     return heat.concat(Array.isArray(entry) ? entry : [entry]);

--- a/src/utils/async.js
+++ b/src/utils/async.js
@@ -1,21 +1,16 @@
-const pack = module.exports.pack = promise =>
-  promise
-  .then(result => [null, result])
-  .catch(err => [err]);
+const pack = (module.exports.pack = promise => promise.then(result => [null, result]).catch(err => [err]));
 
-module.exports.packs = fn =>
-  (...fnArgs) => pack(fn(...fnArgs));
+module.exports.packs = fn => (...fnArgs) => pack(fn(...fnArgs));
 
-const throws = module.exports.throws = packed => {
+const throws = (module.exports.throws = packed => {
   if (packed[0]) {
     throw packed[0];
   }
 
   return packed;
-};
+});
 
-module.exports.unpack = (packed, ignoreErrors) =>
-  ignoreErrors ? packed[1] : throws(packed)[1];
+module.exports.unpack = (packed, ignoreErrors) => (ignoreErrors ? packed[1] : throws(packed)[1]);
 
 const requireAsync = async path => require(path);
 

--- a/src/utils/branding.js
+++ b/src/utils/branding.js
@@ -2,67 +2,56 @@
 const { bad, blue, cyan, dim, green, hvy, magenta, red, yellow } = require('./color');
 const { NEWLINE, zipTemplateLiterals } = require('./strings');
 
-const COLORS = [blue, cyan, green, magenta, red, yellow];
-
-const SHADED_PATTERN = /([▗▙])\s([▜▘])/g;
-
-const WORM = `
- ▗▓▓▓▓▙   ▟▓▓▓▓▙   ▟▓▓▓▓▖
- ▓▓▓▓▓▓▙ ▜▓▓▓▓▓▓▙ ▜▓▓▓▓▓▓
- ▓▓▓ ▜▓▓▙ ▜▛  ▜▓▓▙ ▜▛ ▓▓▓
- ▓▓▓ ▝▓▓▓▙ ▘  ▝▓▓▓▙ ▘ ▓▓▓
- ▓▓▓  ▝▓▓▓▖    ▝▓▓▓▖  ▓▓▓
- ▓▓▓ ▗ ▜▓▓▓▖  ▗ ▜▓▓▓▖ ▓▓▓
- ▓▓▓ ▟▙ ▜▓▓▙  ▟▙ ▜▓▓▙ ▓▓▓
- ▓▓▓▓▓▓▙ ▜▓▓▓▓▓▓▙ ▜▓▓▓▓▓▓
- ▝▓▓▓▓▛   ▜▓▓▓▓▛   ▜▓▓▓▓▘`;
-
-const AUNTY = `
-                                   ▗▄▄
-                                   ▓▓▓
- ▜▓▓▓▓▓▙▖  ▓▓▓    ▓▓▓  ▓▓▙▟▓▓▓▓▙▖ ▓▓▓▓▓▛ ▜▓▙    ▗▓▓▘
-     ▝▓▓▓  ▓▓▓    ▓▓▓  ▓▓▓▛  ▝▓▓▓  ▓▓▓    ▜▓▙  ▗▓▓▘
-▗▟▓▓▓▓▓▓▓  ▓▓▓    ▓▓▓  ▓▓▓    ▓▓▓  ▓▓▓     ▜▓▙▗▓▓▘
-▓▓▓  ▗▓▓▓  ▓▓▓▖  ▟▓▓▓  ▓▓▓    ▓▓▓  ▓▓▓▖     ▜▓▓▓▘
-▝▜▓▓▓▛▜▓▓▓  ▜▓▓▓▓▛▜▓▓  ▓▓▓    ▓▓▓  ▝▓▓▓▓▖   ▗▓▓▘
-                                           ▗▓▓▘
-                                         ▟▓▓▛`;
+const COLORS = [blue, cyan, green, magenta, yellow];
 
 function pickRandomColor() {
   return COLORS[Math.floor(Math.random() * COLORS.length)];
 }
 
-const color = pickRandomColor();
-
-module.exports.createLogo = () => {
-  const worm = WORM
-  .split(NEWLINE)
-  .map((line, index, lines) => color(line.replace(
-    SHADED_PATTERN,
-    (match, $1, $2) => (index < (lines.length / 2)) ?
-      `${$1} ${dim($2)}` : `${dim($1)} ${$2}`
-    )))
-  .join(NEWLINE);
-
-  return zipTemplateLiterals([worm, dim(AUNTY)], 3);
-};
-
-module.exports.createCommandLogo = commandName => zipTemplateLiterals([color(`
+const createLogo = (module.exports.createLogo = color =>
+  (color || pickRandomColor())(`
 ⣾${dim('⢷')}⡾⢷${dim('⡾')}⣷ 
-⢿⡾${dim('⢷⡾')}⢷⡿ `), `
+⢿⡾${dim('⢷⡾')}⢷⡿ `));
+
+module.exports.createCommandLogo = commandName =>
+  zipTemplateLiterals([
+    createLogo(),
+    `
 ${dim('aunty')}
-${hvy(commandName)}`]);
+${hvy(commandName)}`
+  ]);
 
-module.exports.createErrorLogo = () => {
-  const worm = WORM.replace(/(.)/g, (match, $1) => `${pickRandomColor()($1)}`);
-  const text = '  ERROЯ  '.replace(/(.)/g, (match, $1) => `${NEWLINE} ${bad($1)}`);
-
-  return zipTemplateLiterals([worm, text, worm, text, worm]);
-};
+module.exports.createErrorLogo = commandName =>
+  zipTemplateLiterals([
+    createLogo(red),
+    `
+${red(dim('ERROR'))}
+${red(hvy('ЯOЯЯƎ'))}`
+  ]);
 
 module.exports.SPINNER_FRAMES = [
-  '⣏⠀⠀', '⡟⠀⠀', '⠟⠄⠀', '⠛⡄⠀', '⠙⣄⠀', '⠘⣤⠀',
-  '⠐⣤⠂', '⠀⣤⠃', '⠀⣠⠋', '⠀⢠⠛', '⠀⠠⠻', '⠀⠀⢻',
-  '⠀⠀⣹', '⠀⠀⣼', '⠀⠐⣴', '⠀⠘⣤', '⠀⠙⣄', '⠀⠛⡄',
-  '⠠⠛⠄', '⢠⠛⠀', '⣠⠋⠀', '⣤⠃⠀', '⣦⠂⠀', '⣧⠀⠀'
+  '⣏⠀⠀',
+  '⡟⠀⠀',
+  '⠟⠄⠀',
+  '⠛⡄⠀',
+  '⠙⣄⠀',
+  '⠘⣤⠀',
+  '⠐⣤⠂',
+  '⠀⣤⠃',
+  '⠀⣠⠋',
+  '⠀⢠⠛',
+  '⠀⠠⠻',
+  '⠀⠀⢻',
+  '⠀⠀⣹',
+  '⠀⠀⣼',
+  '⠀⠐⣴',
+  '⠀⠘⣤',
+  '⠀⠙⣄',
+  '⠀⠛⡄',
+  '⠠⠛⠄',
+  '⢠⠛⠀',
+  '⣠⠋⠀',
+  '⣤⠃⠀',
+  '⣦⠂⠀',
+  '⣧⠀⠀'
 ];

--- a/src/utils/git.js
+++ b/src/utils/git.js
@@ -11,22 +11,18 @@ const PATTERNS = {
 };
 
 function git(args = [], options = {}) {
-  args = (typeof args === 'string') ? args.split(' ') : args;
+  args = typeof args === 'string' ? args.split(' ') : args;
 
   return execa('git', args, options);
 }
 
-module.exports.isRepo = async cwd =>
-  !(await pack(git('rev-parse --git-dir', {cwd})))[0];
+module.exports.isRepo = async cwd => !(await pack(git('rev-parse --git-dir', { cwd })))[0];
 
-module.exports.getConfigValue = async key =>
-  (await git(`config --get ${key}`)).stdout;
+module.exports.getConfigValue = async key => (await git(`config --get ${key}`)).stdout;
 
-module.exports.getRemotes = async () =>
-  new Set((await git('remote')).stdout.split(NEWLINE).filter(x => x));
+module.exports.getRemotes = async () => new Set((await git('remote')).stdout.split(NEWLINE).filter(x => x));
 
-module.exports.hasChanges = async () =>
-  (await git('status -s')).stdout.length > 0;
+module.exports.hasChanges = async () => (await git('status -s')).stdout.length > 0;
 
 module.exports.getCurrentLabel = async () => {
   const stdout = (await git('branch')).stdout;
@@ -36,20 +32,16 @@ module.exports.getCurrentLabel = async () => {
   return detachedHeadCommit || branch;
 };
 
-module.exports.getCurrentTags = async () =>
-  new Set((await git('tag -l --points-at HEAD')).stdout.split(NEWLINE));
+module.exports.getCurrentTags = async () => new Set((await git('tag -l --points-at HEAD')).stdout.split(NEWLINE));
 
-module.exports.hasTag = async tag =>
-  !(await pack(git(`show-ref --tags --verify refs/tags/${tag}`)))[0];
+module.exports.hasTag = async tag => !(await pack(git(`show-ref --tags --verify refs/tags/${tag}`)))[0];
 
-module.exports.createTag = tag =>
-  git(['tag', '-a', tag, '-m', `"Tagging version ${tag}"`]);
+module.exports.createTag = tag => git(['tag', '-a', tag, '-m', `"Tagging version ${tag}"`]);
 
-module.exports.pushTag = (remote, tag) =>
-  git(['push', remote, tag]);
+module.exports.pushTag = (remote, tag) => git(['push', remote, tag]);
 
 module.exports.createRepo = async cwd => {
-  await git('init', {cwd});
-  await git('add .', {cwd});
-  return git(['commit', '-m', '"Initial commit"'], {cwd});
+  await git('init', { cwd });
+  await git('add .', { cwd });
+  return git(['commit', '-m', '"Initial commit"'], { cwd });
 };

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -14,7 +14,7 @@ const { opt, sec } = require('./color');
 
 inspect.styles.name = 'blue';
 
-const UTIL_INSPECT_OPTIONS = {colors: true, depth: null};
+const UTIL_INSPECT_OPTIONS = { colors: true, depth: null };
 
 module.exports.log = log;
 module.exports.info = (...args) => info(...[logSymbols.info].concat(args));
@@ -23,36 +23,31 @@ module.exports.warn = (...args) => warn(...[logSymbols.warning].concat(args));
 module.exports.error = (...args) => error(...[logSymbols.error].concat(args));
 
 // Can be used as a funtion or a tagged template literal;
-const pretty = module.exports.pretty = (inputs, ...values) => {
-  if (
-    values.length === 0 ||
-    !Array.isArray(inputs) ||
-    inputs.filter(str => typeof str !== 'string').length > 0
-  ) {
+const pretty = (module.exports.pretty = (inputs, ...values) => {
+  if (values.length === 0 || !Array.isArray(inputs) || inputs.filter(str => typeof str !== 'string').length > 0) {
     values = [...arguments];
     inputs = values.map(() => '');
   }
 
   const pairWithValue = (str, index) => {
     const value = values[index];
-    const valueStr = (
-      value == null ? '' :
-      typeof value === 'string' ? value :
-      inspect(value, UTIL_INSPECT_OPTIONS)
-    );
+    const valueStr = value == null ? '' : typeof value === 'string' ? value : inspect(value, UTIL_INSPECT_OPTIONS);
 
     return str + valueStr;
   };
 
   return inputs.map(pairWithValue).join('');
-};
+});
 
 module.exports.dry = config => {
-  Object.keys(config).forEach(key => log(
-`${opt('[dry]')} ${sec(key)}
+  Object.keys(config).forEach(key =>
+    log(
+      `${opt('[dry]')} ${sec(key)}
 
 ${pretty`${config[key]}`}
-`));
+`
+    )
+  );
 };
 
 module.exports.spin = text => {
@@ -67,4 +62,3 @@ module.exports.spin = text => {
 
   return spinner.start();
 };
-

--- a/src/utils/npm.js
+++ b/src/utils/npm.js
@@ -2,7 +2,7 @@
 const execa = require('execa');
 
 function npm(args = [], options = {}) {
-  args = (typeof args === 'string') ? args.split(' ') : args;
+  args = typeof args === 'string' ? args.split(' ') : args;
 
   return execa('npm', args, options);
 }
@@ -10,5 +10,5 @@ function npm(args = [], options = {}) {
 module.exports.install = (args = [], cwd) => {
   args = ['install', '--silent', '--no-progress'].concat(args);
 
-  return npm(args, {cwd});
+  return npm(args, { cwd });
 };

--- a/src/utils/strings.js
+++ b/src/utils/strings.js
@@ -11,50 +11,50 @@ module.exports.SPACE = SPACE;
 
 const identity = x => x;
 
-const getLongest = items =>
-  items.reduce((a, b) => a.length > b.length ? a : b);
+const getLongest = items => items.reduce((a, b) => (a.length > b.length ? a : b));
 
-module.exports.indented = (str, indent = 2) =>
-  str.split(`${NEWLINE}`).join(`${NEWLINE}${SPACE.repeat(indent)}`);
+module.exports.indented = (str, indent = 2) => str.split(`${NEWLINE}`).join(`${NEWLINE}${SPACE.repeat(indent)}`);
 
-module.exports.bulleted = strs =>
-  strs.map(str => `• ${str}`).join(NEWLINE);
+module.exports.bulleted = strs => strs.map(str => `• ${str}`).join(NEWLINE);
 
 module.exports.inlineList = strs =>
-  strs.reduce((acc, str, index) =>
-    [acc, str].join(index === strs.length - 1 ? ' & ' : ', '));
+  strs.reduce((acc, str, index) => [acc, str].join(index === strs.length - 1 ? ' & ' : ', '));
 
-const padding = module.exports.padding = (str, len, char = SPACE) =>
-  char.repeat(len > str.length ? len - str.length : 0);
+const padding = (module.exports.padding = (str, len, char = SPACE) =>
+  char.repeat(len > str.length ? len - str.length : 0));
 
-module.exports.padLeft = (str, len, char = SPACE) =>
-  padding(str, len, char) + String(str);
+module.exports.padLeft = (str, len, char = SPACE) => padding(str, len, char) + String(str);
 
-const padRight = module.exports.padRight = (str, len, char = SPACE) =>
-  String(str) + padding(str, len, char);
+const padRight = (module.exports.padRight = (str, len, char = SPACE) => String(str) + padding(str, len, char));
 
 module.exports.listPairs = (obj, style = identity) => {
   const keys = Object.keys(obj);
   const longest = getLongest(keys).length;
 
-  return keys.map(key => {
-    return `${style(padRight(key, longest))}  ${obj[key]}`;
-  }).join(NEWLINE);
+  return keys
+    .map(key => {
+      return `${style(padRight(key, longest))}  ${obj[key]}`;
+    })
+    .join(NEWLINE);
 };
 
 module.exports.zipTemplateLiterals = (literals, numSpacesBetween) => {
   const literalsLines = literals.map(literal => literal.split(NEWLINE));
 
-  return literalsLines[0].reduce((memo, _, index) => [memo, NEWLINE].join(
-    literalsLines.map(lines => lines[index]).join(SPACE.repeat(numSpacesBetween))
-  ), EMPTY);
+  return literalsLines[0].reduce(
+    (memo, _, index) =>
+      [memo, NEWLINE].join(literalsLines.map(lines => lines[index]).join(SPACE.repeat(numSpacesBetween))),
+    EMPTY
+  );
 };
 
 module.exports.styleLastSegment = (str, style = identity, separator = SLASH) => {
-  return str.split(separator).map((segment, index, segments) => {
-    return (index === segments.length - 1) ? style(segment) : segment;
-  }).join(separator);
+  return str
+    .split(separator)
+    .map((segment, index, segments) => {
+      return index === segments.length - 1 ? style(segment) : segment;
+    })
+    .join(separator);
 };
 
-module.exports.slugToCamel = slug =>
-  slug.replace(CAMELABLE_PATTERN, x => x.slice(1).toUpperCase());
+module.exports.slugToCamel = slug => slug.replace(CAMELABLE_PATTERN, x => x.slice(1).toUpperCase());

--- a/templates/_common/src/components/App.scss
+++ b/templates/_common/src/components/App.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  align-items: center;  
+  align-items: center;
   width: 100%;
   height: 100%;
   min-height: 320px;
@@ -12,10 +12,7 @@
 
   h1 {
     margin-bottom: 0;
-    font-family: -apple-system,
-      BlinkMacSystemFont, "Segoe UI",
-      Roboto, Helvetica, Arial,
-      sans-serif !important;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif !important;
     font-size: 24px !important;
     font-weight: normal !important;
     line-height: normal !important;

--- a/templates/basic-app/src/components/App.js
+++ b/templates/basic-app/src/components/App.js
@@ -1,12 +1,12 @@
 const styles = require('./App.scss');
 const worm = require('./worm.svg');
 
-function App() {
+function App({ projectName }) {
   this.el = document.createElement('div');
   this.el.className = styles.root;
   this.el.innerHTML = `
     <img class="${styles.worm}" src="${worm}" />
-    <h1>{{projectName}}</h1>
+    <h1>${projectName}</h1>
   `;
 }
 

--- a/templates/basic-app/src/components/ErrorBox.js
+++ b/templates/basic-app/src/components/ErrorBox.js
@@ -1,17 +1,17 @@
 const style = require('./ErrorBox.css');
 
-function ErrorBox(err) {
-  const el = this.el = document.createElement('pre');
+function ErrorBox({ error }) {
+  const el = (this.el = document.createElement('pre'));
 
   el.className = style;
-  el.textContent = err.stack;
+  el.textContent = error.stack;
 
   (function logOnMount() {
     if (!el.parentNode) {
       return setTimeout(logOnMount, 100);
     }
 
-    console.error(err);
+    console.error(error);
   })();
 }
 

--- a/templates/basic-app/src/index.js
+++ b/templates/basic-app/src/index.js
@@ -1,9 +1,10 @@
-const root = document.querySelector('[data-{{projectName}}-root]');
+const PROJECT_NAME = '{{projectName}}';
+const root = document.querySelector(`[data-${PROJECT_NAME}-root]`);
 
 function init() {
   const App = require('./components/App');
 
-  root.appendChild((new App()).el);
+  root.appendChild(new App({ projectName: PROJECT_NAME }).el);
 }
 
 init();
@@ -17,11 +18,11 @@ if (module.hot) {
     } catch (err) {
       const ErrorBox = require('./components/ErrorBox');
 
-      root.appendChild((new ErrorBox(err)).el);
+      root.appendChild(new ErrorBox({ error: err }).el);
     }
   });
 }
 
 if (process.env.NODE_ENV === 'development') {
-  console.debug(`[{{projectName}}] public path: ${__webpack_public_path__}`);
+  console.debug(`[${PROJECT_NAME}] public path: ${__webpack_public_path__}`);
 }

--- a/templates/preact-app/src/components/App.js
+++ b/templates/preact-app/src/components/App.js
@@ -1,13 +1,13 @@
-const {h, Component} = require('preact');
+const { h, Component } = require('preact');
 const styles = require('./App.scss');
 const worm = require('./worm.svg');
 
 class App extends Component {
-  render() {
+  render({ projectName }) {
     return (
       <div className={styles.root}>
         <img className={styles.worm} src={worm} />
-        <h1>{{projectName}}</h1>
+        <h1>{projectName}</h1>
       </div>
     );
   }

--- a/templates/preact-app/src/components/ErrorBox.js
+++ b/templates/preact-app/src/components/ErrorBox.js
@@ -1,4 +1,4 @@
-const {h, Component} = require('preact');
+const { h, Component } = require('preact');
 const styles = require('./ErrorBox.css');
 
 class ErrorBox extends Component {
@@ -7,11 +7,7 @@ class ErrorBox extends Component {
   }
 
   render() {
-    return (
-      <pre className={styles.root}>
-        {this.props.error.stack}
-      </pre>
-    );
+    return <pre className={styles.root}>{this.props.error.stack}</pre>;
   }
 }
 

--- a/templates/preact-app/src/index.js
+++ b/templates/preact-app/src/index.js
@@ -1,11 +1,12 @@
-const {h, render} = require('preact');
+const { h, render } = require('preact');
 
-const root = document.querySelector('[data-{{projectName}}-root]');
+const PROJECT_NAME = '{{projectName}}';
+const root = document.querySelector(`[data-${PROJECT_NAME}-root]`);
 
 function init() {
   const App = require('./components/App');
 
-  render(<App />, root, root.firstChild);
+  render(<App projectName={PROJECT_NAME} />, root, root.firstChild);
 }
 
 init();
@@ -24,6 +25,6 @@ if (module.hot) {
 
 if (process.env.NODE_ENV === 'development') {
   require('preact/devtools');
-  
-  console.debug(`[{{projectName}}] public path: ${__webpack_public_path__}`);
+
+  console.debug(`[${PROJECT_NAME}] public path: ${__webpack_public_path__}`);
 }

--- a/templates/react-app/src/components/App.js
+++ b/templates/react-app/src/components/App.js
@@ -7,7 +7,7 @@ class App extends React.Component {
     return (
       <div className={styles.root}>
         <img className={styles.worm} src={worm} />
-        <h1>{{projectName}}</h1>
+        <h1>{this.props.projectName}</h1>
       </div>
     );
   }

--- a/templates/react-app/src/components/ErrorBox.js
+++ b/templates/react-app/src/components/ErrorBox.js
@@ -7,11 +7,7 @@ class ErrorBox extends React.Component {
   }
 
   render() {
-    return (
-      <pre className={styles.root}>
-        {this.props.error.stack}
-      </pre>
-    );
+    return <pre className={styles.root}>{this.props.error.stack}</pre>;
   }
 }
 

--- a/templates/react-app/src/index.js
+++ b/templates/react-app/src/index.js
@@ -1,12 +1,13 @@
 const React = require('react');
-const {render} = require('react-dom');
+const { render } = require('react-dom');
 
-const root = document.querySelector('[data-{{projectName}}-root]');
+const PROJECT_NAME = '{{projectName}}';
+const root = document.querySelector(`[data-${PROJECT_NAME}-root]`);
 
 function init() {
   const App = require('./components/App');
 
-  render(<App />, root);
+  render(<App projectName={PROJECT_NAME} />, root);
 }
 
 init();
@@ -24,5 +25,5 @@ if (module.hot) {
 }
 
 if (process.env.NODE_ENV === 'development') {
-  console.debug(`[{{projectName}}] public path: ${__webpack_public_path__}`);
+  console.debug(`[${PROJECT_NAME}] public path: ${__webpack_public_path__}`);
 }


### PR DESCRIPTION
Also:

* Re-formatted codebase with `prettier`.
* Removed `xo` linting tool & config.
* Removed big aunty logos, opting for smaller command-style (even for exit-causing errors).
* Edited project template components to play nicer with prettier auto-formatting.
* Added @drzax as a contributor to `README.md` and `package.json`