### PR TITLE
The release command now lets you bump the major/minor/patch version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@abcnews/aunty",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2797,6 +2797,7 @@
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -3201,6 +3202,7 @@
           "version": "2.2.2",
           "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
           "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+          "dev": true,
           "requires": {
             "globby": "5.0.0",
             "is-path-cwd": "1.0.0",
@@ -3215,6 +3217,7 @@
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -3228,6 +3231,7 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
           "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+          "dev": true,
           "requires": {
             "array-union": "1.0.2",
             "arrify": "1.0.1",
@@ -3240,7 +3244,8 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
         }
       }
     },
@@ -3963,13 +3968,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3977,6 +3975,13 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -8978,14 +8983,6 @@
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -8994,6 +8991,14 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {
@@ -9104,17 +9109,20 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
         },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
             "strip-ansi": "4.0.0"
@@ -10046,6 +10054,53 @@
         "graceful-fs": "4.1.11",
         "imurmurhash": "0.1.4",
         "slide": "1.1.6"
+      }
+    },
+    "write-json-file": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.3.0.tgz",
+      "integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
+      "requires": {
+        "detect-indent": "5.0.0",
+        "graceful-fs": "4.1.11",
+        "make-dir": "1.0.0",
+        "pify": "3.0.0",
+        "sort-keys": "2.0.0",
+        "write-file-atomic": "2.1.0"
+      },
+      "dependencies": {
+        "detect-indent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
+        },
+        "sort-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+          "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+          "requires": {
+            "is-plain-obj": "1.1.0"
+          }
+        }
+      }
+    },
+    "write-pkg": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-3.1.0.tgz",
+      "integrity": "sha1-AwqZlMyZk9JbTnWp8aGSNgcpHOk=",
+      "requires": {
+        "sort-keys": "2.0.0",
+        "write-json-file": "2.3.0"
+      },
+      "dependencies": {
+        "sort-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+          "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+          "requires": {
+            "is-plain-obj": "1.1.0"
+          }
+        }
       }
     },
     "xdg-basedir": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "resolve": "^1.2.0",
     "rsyncwrapper": "^2.0.1",
     "sass-loader": "^6.0.6",
+    "semver": "^5.4.1",
     "ssh2": "^0.5.4",
     "style-loader": "^0.18.2",
     "through2": "^2.0.3",
@@ -53,7 +54,8 @@
     "vinyl-ftp": "^0.6.0",
     "webpack": "^3.5.5",
     "webpack-dev-server": "^2.7.1",
-    "webpack-merge": "^4.1.0"
+    "webpack-merge": "^4.1.0",
+    "write-pkg": "^3.1.0"
   },
   "devDependencies": {
     "eslint": "^4.8.0",

--- a/src/commands/deploy/index.js
+++ b/src/commands/deploy/index.js
@@ -132,7 +132,7 @@ module.exports.deploy = command(
         {
           __key__: key,
           id: config.id,
-          name: config.name,
+          name: config.pkg.name,
           files: '**'
         },
         credentials[key],

--- a/src/commands/release/constants.js
+++ b/src/commands/release/constants.js
@@ -2,9 +2,10 @@
 const { cmd, hvy, opt, sec } = require('../../utils/color');
 
 const FORCE_REMINDER = `Use the ${opt('--force')} option to ignore warnings or release without tagging.`;
+const VALID_BUMPS = (module.exports.VALID_BUMPS = new Set(['major', 'minor', 'patch']));
 
 module.exports.OPTIONS = {
-  string: ['git-remote'],
+  string: ['bump', 'git-remote'],
   default: {
     'git-remote': 'origin'
   }
@@ -14,6 +15,11 @@ module.exports.MESSAGES = {
   FORCE_REMINDER: `Use the ${opt('--force')} option to ignore warnings or release without tagging.`,
   NOT_REPO: `You can't tag a release or deploy using a tag name becase this project isn't a git repo.`,
   HAS_CHANGES: `You shouldn't release builds which may contain un-committed changes! ${FORCE_REMINDER}`,
+  invalidHead: label => `You are trying to release from ${hvy(label)}. You should only release from ${hvy('master')}`,
+  invalidBump: bump =>
+    `You supplied an invalid bump value ${hvy(bump)}. It can be: ${hvy(Array.from(VALID_BUMPS).join('|'))}`,
+  createBump: (bump, from, to) => `Bump ${hvy(bump)} version ${hvy(from)}=>${hvy(to)}`,
+  pushBump: remote => `Push bump to remote ${hvy(remote)}`,
   hasTag: (tag, isTagOnHead) =>
     `The tag ${hvy(tag)} already exists${isTagOnHead
       ? ''
@@ -25,9 +31,12 @@ Usage: ${cmd(`aunty ${name}`)} ${opt('[options] [build_options] [deploy_options]
 
 ${sec('Options')}
 
-  ${opt('-d')}, ${opt('--dry')}     Output the release version, then exit
-  ${opt('-f')}, ${opt('--force')}   Ignore warnings & skip tagging ${opt('[default: false]')}
-  ${opt('--git-remote')}  Git remote to push release tags to (if it exists) ${opt('[default: "origin"]')}
+  ${opt('-d')}, ${opt('--dry')}                   Output the release version, then exit
+  ${opt('-f')}, ${opt('--force')}                 Ignore warnings & skip tagging ${opt('[default: false]')}
+  ${opt(`--bump={${Array.from(VALID_BUMPS).join('|')}}`)}  Bump the package version as part of the release ${opt(
+    '[default: null]'
+  )}
+  ${opt('--git-remote')}                Git remote to push release tags to (if it exists) ${opt('[default: "origin"]')}
 
 ${sec('Examples')}
 
@@ -37,6 +46,15 @@ ${sec('Examples')}
       2. Run \`${cmd('aunty build')} ${opt('--target=<target_name> --id=<package.json:version>')}\`
       3. Tag a release with ${hvy('git')} (using ${hvy('package.json:version')}), pushing it to any remotes
       4. Run \`${cmd('aunty deploy')} ${opt('--target=<target_name> --id=<package.json:version>')}\`
+
+  ${cmd('aunty release --bump=major')}
+    For each deployment target specified in the project's config:
+      1. Check for uncommitted local changes (exiting if any exist)
+      2. Bump the major version in ${hvy('package.json')} & commit, pushing it to any remotes
+      3. Run \`${cmd('aunty build')} ${opt('--target=<target_name> --id=<package.json:version>')}\`
+      4. Tag a release with ${hvy('git')} (using ${hvy('package.json:version')}), pushing it to any remotes
+      5. Run \`${cmd('aunty deploy')} ${opt('--target=<target_name> --id=<package.json:version>')}\`
+
 
   ${cmd(`aunty release ${opt('--force')}`)}
     For each deployment target specified in the project's config:

--- a/src/commands/release/index.js
+++ b/src/commands/release/index.js
@@ -1,3 +1,6 @@
+// External
+const semver = require('semver');
+
 // Ours
 const { command } = require('../../cli');
 const { throws } = require('../../utils/async');
@@ -16,7 +19,7 @@ module.exports.release = command(
     isConfigRequired: true
   },
   async (argv, config) => {
-    const id = config.version;
+    const id = config.pkg.version;
     let spinner;
 
     const targets = argv.target ? [argv.target] : Object.keys(config.deploy);

--- a/src/commands/release/index.js
+++ b/src/commands/release/index.js
@@ -1,15 +1,30 @@
 // External
 const semver = require('semver');
+const writePkg = require('write-pkg');
 
 // Ours
 const { command } = require('../../cli');
-const { throws } = require('../../utils/async');
-const { createTag, getCurrentTags, getRemotes, hasChanges, hasTag, isRepo, pushTag } = require('../../utils/git');
+const { packs, throws } = require('../../utils/async');
+const {
+  commitAll,
+  createTag,
+  getCurrentLabel,
+  getCurrentTags,
+  getRemotes,
+  hasChanges,
+  hasTag,
+  isRepo,
+  push,
+  pushTag
+} = require('../../utils/git');
 const { dry, spin } = require('../../utils/logging');
 const { build } = require('../build');
 const { deploy } = require('../deploy');
 const { MESSAGES: DEPLOY_MESSAGES } = require('../deploy/constants');
-const { MESSAGES, OPTIONS } = require('./constants');
+const { MESSAGES, OPTIONS, VALID_BUMPS } = require('./constants');
+
+// Wrapped
+const setPkg = packs(writePkg);
 
 module.exports.release = command(
   {
@@ -19,10 +34,18 @@ module.exports.release = command(
     isConfigRequired: true
   },
   async (argv, config) => {
-    const id = config.pkg.version;
-    let spinner;
+    if (argv.bump && !VALID_BUMPS.has(argv.bump)) {
+      throw MESSAGES.invalidBump(argv.bump);
+    }
 
+    const id =
+      argv.bump && VALID_BUMPS.has(argv.bump) && semver.valid(config.pkg.version)
+        ? semver.inc(config.pkg.version, argv.bump)
+        : config.pkg.version;
+    const remote = argv['git-remote'];
     const targets = argv.target ? [argv.target] : Object.keys(config.deploy);
+    let remotes;
+    let spinner;
 
     if (argv.dry) {
       return dry({
@@ -30,16 +53,20 @@ module.exports.release = command(
       });
     }
 
-    // 1) Ensure the project is a git repo
+    // 1) Ensure the project is a git repo and discover remotes
 
     if (!await isRepo()) {
       throw MESSAGES.NOT_REPO;
     }
 
-    // 2) Ensure the project has a deployment config
+    remotes = await getRemotes();
 
-    if (typeof config.deploy !== 'object') {
-      throw DEPLOY_MESSAGES.NO_TARGETS;
+    // 2) Ensure the master branch is checked out (skippable)
+
+    const label = await getCurrentLabel();
+
+    if (!argv.force && label !== 'master') {
+      throw MESSAGES.invalidHead(label);
     }
 
     // 3) Ensure the project no un-committed changes (skippable)
@@ -48,23 +75,38 @@ module.exports.release = command(
       throw MESSAGES.HAS_CHANGES;
     }
 
-    // 4) Do a quick build to see that there are no build errors before we tag
+    // 4) Ensure the project has a deployment config
+
+    if (typeof config.deploy !== 'object') {
+      throw DEPLOY_MESSAGES.NO_TARGETS;
+    }
+
+    // 5) Do a quick build to see that there are no build errors before we tag
 
     throws(await build(['--id', id, '--target', targets[0], '--preflight']));
 
-    // 5) Tag a new release (skippable)
+    // 6) Bump the project's version number (optional, skippable)
+
+    if (!argv.force && argv.bump) {
+      spinner = spin(MESSAGES.createBump(argv.bump, config.pkg.version, id));
+      config.pkg.version = id;
+      await writePkg(config.root, config.pkg);
+      await commitAll(id);
+      spinner.succeed();
+
+      if (remotes.has(remote)) {
+        spinner = spin(MESSAGES.pushBump(remote));
+        await push();
+        spinner.succeed();
+      }
+    }
+
+    // 7) Tag a new release (skippable)
 
     if (!argv.force) {
-      if (await hasTag(id)) {
-        throw MESSAGES.hasTag(id, (await getCurrentTags()).has(id));
-      }
-
       spinner = spin(MESSAGES.createTag(id));
       await createTag(id);
       spinner.succeed();
-
-      const remotes = await getRemotes();
-      const remote = argv['git-remote'];
 
       if (remotes.has(remote)) {
         spinner = spin(MESSAGES.pushTag(id, remote));
@@ -73,7 +115,7 @@ module.exports.release = command(
       }
     }
 
-    // 6) For each target, build the project and deploy it
+    // 8) For each target, build the project and deploy it
 
     await Promise.all(
       targets.map(async (target, index) => {

--- a/src/projects/config.js
+++ b/src/projects/config.js
@@ -32,7 +32,7 @@ function resolveDeployConfig(config) {
     }
 
     target.from = `${config.root}/${target._from}`;
-    target.to = target._to.replace('<name>', config.name).replace('<id>', config.id);
+    target.to = target._to.replace('<name>', config.pkg.name).replace('<id>', config.id);
     target.publicURL = KNOWN_TARGETS[key]
       ? target.to.replace(KNOWN_TARGETS[key].publicPathRewritePattern, `${KNOWN_TARGETS[key].publicURLRoot}$1/`)
       : null;
@@ -70,9 +70,8 @@ module.exports.getConfig = packs(async argv => {
 
     config = Object.assign(
       {
-        name: pkg.name,
-        version: pkg.version,
-        root
+        root,
+        pkg
       },
       auntyConfig
     );

--- a/src/projects/config.js
+++ b/src/projects/config.js
@@ -51,7 +51,7 @@ module.exports.getConfig = packs(async argv => {
   }
 
   if (!pkg) {
-    pkg = unpack(await getPkg(root));
+    pkg = unpack(await getPkg(root, { normalize: false }));
   }
 
   if (!config) {

--- a/src/utils/git.js
+++ b/src/utils/git.js
@@ -32,6 +32,10 @@ module.exports.getCurrentLabel = async () => {
   return detachedHeadCommit || branch;
 };
 
+module.exports.commitAll = message => git(['commit', '-a', '-m', `"${message}"`]);
+
+module.exports.push = () => git('push');
+
 module.exports.getCurrentTags = async () => new Set((await git('tag -l --points-at HEAD')).stdout.split(NEWLINE));
 
 module.exports.hasTag = async tag => !(await pack(git(`show-ref --tags --verify refs/tags/${tag}`)))[0];


### PR DESCRIPTION
It'll also push the commit ahead of tagging. This removes the need to manually bump and commit ahead of releases beyond 1.0.0.

Suppose you've added a feature after the 1.0.0 release; you can now run:

`aunty release --bump minor`

which will do the following:

```
⣾⢷⡾⢷⡾⣷ aunty
⢿⡾⢷⡾⢷⡿ release

✔ Clean
✔ Preflight
✔ Bump minor version 1.0.0=>1.1.0
✔ Push bump to remote origin
✔ Create tag 1.1.0
✔ Push tag 1.1.0 to remote origin
✔ Build
ℹ Deployment (ftp):
  ┣ from <workspace>/<project_dir>/build
  ┣ to   /www/res/sites/news-projects/<project_dir>/1.1.0
  ┗ on   contentftp.abc.net.au
✔ Deploy
ℹ Public URL: http://www.abc.net.au/res/sites/news-projects/<project_dir>/1.1.0/
```
This change also introduces a new restriction on releases (in addition to having a clean git status): you must be on the master branch.