### PR TITLE
Inside projects, load the local bin/aunty (entry file) instead of the local cli/index

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5244,6 +5244,15 @@
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
       "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
     },
+    "import-local": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-0.1.1.tgz",
+      "integrity": "sha1-sReVcqrNwRxqkQCftDDbyrX2aKg=",
+      "requires": {
+        "pkg-dir": "2.0.0",
+        "resolve-cwd": "2.0.0"
+      }
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -9275,6 +9284,21 @@
       "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
       "requires": {
         "path-parse": "1.0.5"
+      }
+    },
+    "resolve-cwd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+      "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+      "requires": {
+        "resolve-from": "3.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+        }
       }
     },
     "resolve-from": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "postcss-loader": "^2.0.6",
     "pump": "^1.0.2",
     "read-pkg": "^2.0.0",
-    "resolve": "^1.2.0",
     "rsyncwrapper": "^2.0.1",
     "sass-loader": "^6.0.6",
     "semver": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "file-loader": "^0.11.2",
     "guess-root-path": "^1.0.0",
     "html-loader": "^0.5.1",
+    "import-local": "^0.1.1",
     "load-json-file": "^2.0.0",
     "log-symbols": "^2.0.0",
     "minimist": "^1.2.0",

--- a/src/bin/aunty.js
+++ b/src/bin/aunty.js
@@ -1,39 +1,26 @@
 #!/usr/bin/env node
 
-// External
-const resolve = require('resolve');
+if (!require('import-local')(__filename)) {
+  (async () => {
+    const { createErrorLogo } = require('../utils/branding');
+    const { error, log } = require('../utils/logging');
+    const { cli } = require('../cli');
 
-// Ours
-const { name } = require('../../package');
-const { createErrorLogo } = require('../utils/branding');
-const { error, log } = require('../utils/logging');
+    function exit(err) {
+      if (err) {
+        log(createErrorLogo());
+        error(err);
+        process.exit(1);
+      }
 
-function exit(err) {
-  if (err) {
-    log(createErrorLogo());
-    error(err);
-    process.exit(1);
-  }
+      process.exit(0);
+    }
 
-  process.exit(0);
+    process.on('uncaughtException', exit);
+    process.on('unhandledRejection', exit);
+
+    const [err] = await cli(process.argv.slice(2));
+
+    exit(err);
+  })();
 }
-
-process.on('uncaughtException', exit);
-process.on('unhandledRejection', exit);
-
-let cli;
-let isGlobal;
-
-// Always prefer local CLI
-try {
-  cli = require(resolve.sync(`${name}/src/cli`, { basedir: process.cwd() })).cli;
-} catch (err) {
-  isGlobal = true;
-  cli = require('../cli').cli;
-}
-
-(async () => {
-  const [err] = await cli(process.argv.slice(2), isGlobal);
-
-  exit(err);
-})();

--- a/src/cli/constants.js
+++ b/src/cli/constants.js
@@ -43,8 +43,8 @@ module.exports.DEFAULTS = {
 };
 
 module.exports.MESSAGES = {
-  version: (versionNumber, isLocal) => `
-${cmd('aunty')} v${versionNumber}${isLocal ? dim(' (local)') : ''}`,
+  version: versionNumber => `
+${cmd('aunty')} v${versionNumber}`,
   unrecognised: commandName => `Unrecognised command: ${req(commandName)}`,
   usage: () => `${createLogo()}
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -19,15 +19,13 @@ const isArgHelpCommand = arg => {
   return (ALIASES[arg] || arg) === 'help';
 };
 
-module.exports.cli = packs(async (args, isGlobal) => {
+module.exports.cli = packs(async args => {
   const argv = minimist(args, OPTIONS);
 
-  if (isGlobal) {
-    updateNotifier({ pkg, updateCheckInterval: 36e5 }).notify();
-  }
+  updateNotifier({ pkg, updateCheckInterval: 36e5 }).notify();
 
   if (argv.version) {
-    return log(MESSAGES.version(pkg.version, !isGlobal));
+    return log(MESSAGES.version(pkg.version));
   }
 
   let commandName = argv._[0] || '';


### PR DESCRIPTION
Before we had a strange situation where the entry file (when run inside projects) could be global or local, depending on whether `aunty` was run directly, or through npm scripts (which uses `node_modules/.bin/aunty`). This in turn would then try to resolve the local cli.js and pass in whether it knew that cli.js was global or local. The problem with this is that, even when we imported the local cli, the entry-point was still the global aunty, and as such would handle all errors (ewwww).

Now, the entry file itself short-circuits when it knows there's a local alternative it can defer to.

Note: With this change, we lose the opportunity to pass the `isGlobal` flag into the CLI, but it was only used to output `vX.X.X (local)` when the `-v` arg was used inside a project, and conditionally run `update-notifier`, and I don't consider this a loss.