### PR TITLE
Share browsers with postcss

### DIFF
--- a/src/projects/postcss.config.js
+++ b/src/projects/postcss.config.js
@@ -1,5 +1,7 @@
-module.exports = {
+module.exports = ({ options }) => ({
   plugins: {
-    autoprefixer: {}
+    autoprefixer: {
+      browsers: options.browsers
+    }
   }
-};
+});

--- a/src/projects/webpack.js
+++ b/src/projects/webpack.js
@@ -90,6 +90,10 @@ function createWebpackConfig(argv, config) {
     process.noDeprecation = true;
   }
 
+  const browsers = config.buildWithModules
+    ? ['Chrome >= 60', 'Safari >= 10.1', 'iOS >= 10.3', 'Firefox >= 54', 'Edge >= 15']
+    : ['> 1%', 'last 2 versions', 'Firefox ESR'];
+
   let babelOptions = merge(
     {
       presets: [
@@ -97,9 +101,7 @@ function createWebpackConfig(argv, config) {
           require.resolve('babel-preset-env'),
           {
             targets: {
-              browsers: config.buildWithModules
-                ? ['Chrome >= 60', 'Safari >= 10.1', 'iOS >= 10.3', 'Firefox >= 54', 'Edge >= 15']
-                : ['> 1%', 'last 2 versions', 'Firefox ESR']
+              browsers
             },
             useBuiltIns: true,
             modules: false
@@ -159,6 +161,7 @@ function createWebpackConfig(argv, config) {
                 loader: require.resolve('postcss-loader'),
                 options: {
                   config: {
+                    ctx: { browsers },
                     path: `${__dirname}/postcss.config.js`
                   }
                 }


### PR DESCRIPTION
…by adding them to the postcss's context options (`ctx` prop on `postcss-loader`'s config), and updating postcss.config.js to export a function that accepts & uses those options.

By doing this, we'll reduce bundle sizes because autoprefixer won't need to add All The Things™ (and our new shiny "modules" bundles will be even smaller because the number of prefixes added will be close to 0).