### PR TITLE
Auto-select dev server host...

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@abcnews/aunty",
-  "version": "7.7.0",
+  "version": "7.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8535,6 +8535,11 @@
         "fstream": "1.0.11",
         "inherits": "2.0.3"
       }
+    },
+    "tcp-ping": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tcp-ping/-/tcp-ping-0.1.1.tgz",
+      "integrity": "sha1-At1/QrW/fXy3jVt6rO+hVf2PfAw="
     },
     "term-size": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "semver": "^5.4.1",
     "ssh2": "^0.5.4",
     "style-loader": "^0.18.2",
+    "tcp-ping": "^0.1.1",
     "uglifyjs-webpack-plugin": "^1.0.0-rc.0",
     "update-notifier": "^2.1.0",
     "url-loader": "^0.5.9",

--- a/src/commands/build/index.js
+++ b/src/commands/build/index.js
@@ -22,7 +22,7 @@ module.exports.build = command(
       process.env.NODE_ENV = 'production';
     }
 
-    const webpackConfig = createConfig(argv, config);
+    const webpackConfig = await createConfig(argv, config);
 
     if (argv.dry) {
       return dry({

--- a/src/commands/serve/index.js
+++ b/src/commands/serve/index.js
@@ -24,7 +24,7 @@ module.exports.serve = command(
       process.env.NODE_ENV = 'development';
     }
 
-    const [webpackConfig, devServerConfig] = createConfig(argv, config, true);
+    const [webpackConfig, devServerConfig] = await createConfig(argv, config, true);
 
     const { port } = devServerConfig;
 


### PR DESCRIPTION
...based on whether we're on the internal network or not.

If we're inside the ABC network (`nucwed` is reachable), use `<HOSTNAME>.aus.aunty.abc.net.au`.

If we're not, use `localhost`.

Because pinging is an async action, this requires that we make our webpack config generation async too.

Closes #50