### PR TITLE
Updated release command to include interactive version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@abcnews/aunty",
-  "version": "9.5.1",
+  "version": "9.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1865,6 +1865,16 @@
         "lodash": "^4.17.4",
         "source-map": "^0.5.7",
         "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "detect-indent": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+          "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+          "requires": {
+            "repeating": "^2.0.0"
+          }
+        }
       }
     },
     "babel-helpers": {
@@ -2747,6 +2757,27 @@
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
     },
+    "bump-file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/bump-file/-/bump-file-1.0.0.tgz",
+      "integrity": "sha512-mUN6TDIkvDmE6gNlgMDiLl95qcgfqQ5Hu8HZDFk4AW3t9xBcKoasHlMcjV+1C6jmRRX4G2WySML0JGauRzFKaw==",
+      "requires": {
+        "detect-indent": "5.0.0",
+        "semver": "5.4.1"
+      },
+      "dependencies": {
+        "detect-indent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
+        },
+        "semver": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+        }
+      }
+    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -3116,6 +3147,14 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "requires": {
         "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-select": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-select/-/cli-select-1.0.2.tgz",
+      "integrity": "sha512-V3rne+3zFQcwcI/5QpxnQdovY7sjyG5NsvMBcWI+EQDHLeMQ9yLm7AFXW1iLtUUXKjEIxg03ZCMNbQFvyzoSTQ==",
+      "requires": {
+        "ansi-escapes": "^3.0.0"
       }
     },
     "cli-spinners": {
@@ -4030,12 +4069,9 @@
       "integrity": "sha1-CIZXpmqWHAUBnbfEIwiDsca0F24="
     },
     "detect-indent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "requires": {
-        "repeating": "^2.0.0"
-      }
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+      "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
     },
     "detect-newline": {
       "version": "2.1.0",
@@ -5189,6 +5225,16 @@
         "commondir": "^1.0.1",
         "make-dir": "^1.0.0",
         "pkg-dir": "^2.0.0"
+      },
+      "dependencies": {
+        "pkg-dir": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+          "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+          "requires": {
+            "find-up": "^2.1.0"
+          }
+        }
       }
     },
     "find-up": {
@@ -6801,6 +6847,16 @@
       "requires": {
         "pkg-dir": "^2.0.0",
         "resolve-cwd": "^2.0.0"
+      },
+      "dependencies": {
+        "pkg-dir": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+          "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+          "requires": {
+            "find-up": "^2.1.0"
+          }
+        }
       }
     },
     "imurmurhash": {
@@ -7564,6 +7620,16 @@
           "requires": {
             "pkg-dir": "^2.0.0",
             "resolve-cwd": "^2.0.0"
+          },
+          "dependencies": {
+            "pkg-dir": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+              "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+              "requires": {
+                "find-up": "^2.1.0"
+              }
+            }
           }
         },
         "jest-cli": {
@@ -8288,6 +8354,11 @@
       "requires": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "jsonfile-updater": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile-updater/-/jsonfile-updater-3.1.0.tgz",
+      "integrity": "sha512-G6DB55KX4Cc5t0Zpg4kfy2b3N592fahyoUJz5rk4VmS8lccXskgUbjUEX51iXMc6gh6sE7urmXWJsW6EqDozVQ=="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -9771,11 +9842,46 @@
       }
     },
     "pkg-dir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
       "requires": {
-        "find-up": "^2.1.0"
+        "find-up": "^3.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+          "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        }
       }
     },
     "pluralize": {
@@ -13842,6 +13948,54 @@
           "requires": {
             "pkg-dir": "^2.0.0",
             "resolve-cwd": "^2.0.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+              "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+              "requires": {
+                "locate-path": "^2.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+              "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+              "requires": {
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "p-limit": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+              "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+              "requires": {
+                "p-try": "^1.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+              "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+              "requires": {
+                "p-limit": "^1.1.0"
+              }
+            },
+            "p-try": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+              "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+            },
+            "pkg-dir": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+              "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+              "requires": {
+                "find-up": "^2.1.0"
+              }
+            }
           }
         },
         "json-schema-traverse": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "babel-jest": "^21.2.0",
     "babel-loader": "^8.0.0",
     "chalk": "^2.4.1",
+    "cli-select": "^1.0.2",
     "copy-webpack-plugin": "^4.5.2",
     "css-loader": "^0.28.11",
     "del": "^3.0.0",
@@ -42,6 +43,7 @@
     "import-local": "^0.1.1",
     "isomorphic-fetch": "^2.2.1",
     "jest": "^23.5.0",
+    "jsonfile-updater": "^3.1.0",
     "load-json-file": "^2.0.0",
     "log-symbols": "^2.2.0",
     "minimist": "^1.2.0",
@@ -65,7 +67,6 @@
     "webpack": "^4.17.2",
     "webpack-dev-server": "^3.1.7",
     "webpack-merge": "^4.1.4",
-    "write-pkg": "^3.2.0",
     "yeoman-environment": "^2.3.3",
     "yeoman-generator": "^2.0.5"
   },

--- a/src/commands/release/constants.js
+++ b/src/commands/release/constants.js
@@ -1,64 +1,63 @@
 // Ours
-const { cmd, hvy, opt, sec } = require('../../utils/color');
+const { cmd, hvy, ok, opt, sec } = require('../../utils/color');
 
 const FORCE_REMINDER = `Use the ${opt('--force')} option to ignore warnings or release without tagging.`;
 const VALID_BUMPS = (module.exports.VALID_BUMPS = new Set(['major', 'minor', 'patch']));
 
-module.exports.OPTIONS = {
+const OPTIONS = (module.exports.OPTIONS = {
   string: ['bump', 'git-remote'],
   default: {
     'git-remote': 'origin'
   }
-};
+});
 
 module.exports.MESSAGES = {
-  FORCE_REMINDER: `Use the ${opt('--force')} option to ignore warnings or release without tagging.`,
-  NOT_REPO: `You can't tag a release or deploy using a tag name becase this project isn't a git repo.`,
+  BUMP_QUESTION: `${ok('?')} ${hvy('What package version bump is this release?')}`,
+  FORCE_REMINDER,
   HAS_CHANGES: `You shouldn't release builds which may contain un-committed changes! ${FORCE_REMINDER}`,
-  invalidHead: label => `You are trying to release from ${hvy(label)}. You should only release from ${hvy('master')}`,
+  NOT_REPO: `You can't tag a release or deploy using a tag name becase this project isn't a git repo.`,
+  createBump: (bump, from, to) => `Bump ${hvy(bump)} version ${hvy(from)}=>${hvy(to)}`,
+  createTag: tag => `Create tag ${hvy(tag)}`,
+  hasTag: (tag, isTagOnHead) =>
+    `The tag ${hvy(tag)} already exists${
+      isTagOnHead ? '' : ` and your current HEAD doesn't point to it`
+    }! ${FORCE_REMINDER}`,
   invalidBump: bump =>
     `You supplied an invalid bump value ${hvy(bump)}. It can be: ${hvy(Array.from(VALID_BUMPS).join('|'))}`,
-  createBump: (bump, from, to) => `Bump ${hvy(bump)} version ${hvy(from)}=>${hvy(to)}`,
+  invalidHead: label => `You are trying to release from ${hvy(label)}. You should only release from ${hvy('master')}`,
   pushBump: remote => `Push bump to remote ${hvy(remote)}`,
-  hasTag: (tag, isTagOnHead) =>
-    `The tag ${hvy(tag)} already exists${isTagOnHead
-      ? ''
-      : ` and your current HEAD doesn't point to it`}! ${FORCE_REMINDER}`,
-  createTag: tag => `Create tag ${hvy(tag)}`,
   pushTag: (tag, remote) => `Push tag ${hvy(tag)} to remote ${hvy(remote)}`,
   usage: name => `
 Usage: ${cmd(`aunty ${name}`)} ${opt('[options] [build_options] [deploy_options]')}
 
 ${sec('Options')}
 
-  ${opt('-d')}, ${opt('--dry')}                   Output the release version, then exit
-  ${opt('-f')}, ${opt('--force')}                 Ignore warnings & skip tagging ${opt('[default: false]')}
-  ${opt(`--bump={${Array.from(VALID_BUMPS).join('|')}}`)}  Bump the package version as part of the release ${opt(
-    '[default: null]'
+  ${opt(`--bump={${Array.from(VALID_BUMPS).join('|')}}`)}  Preselect the package version bump for this release ${opt(
+    '[default: PROMPT]'
   )}
-  ${opt('--git-remote')}                Git remote to push release tags to (if it exists) ${opt('[default: "origin"]')}
+  ${opt('--git-remote')}                Git remote to push release tags to (if it exists) ${opt(
+    `[default: "${OPTIONS.default['git-remote']}"]`
+  )}
+  ${opt('-d')}, ${opt('--dry')}                   Output the release version & git remote, then exit
+  ${opt('-f')}, ${opt('--force')}                 Ignore warnings & don't bump version ${opt('[default: false]')}
 
 ${sec('Examples')}
 
   ${cmd('aunty release')}
-    For each deployment target specified in the project's config:
-      1. Check for uncommitted local changes (exiting if any exist)
-      2. Run \`${cmd('aunty build')} ${opt('--target=<target_name> --id=<package.json:version>')}\`
-      3. Tag a release with ${hvy('git')} (using ${hvy('package.json:version')}), pushing it to any remotes
-      4. Run \`${cmd('aunty deploy')} ${opt('--target=<target_name> --id=<package.json:version>')}\`
+    1. Ensure working directory is in a deployable state
+    2. Prompt for version bump choice and determine release version
+    3. Ensure project will build for first deploy target
+    4. Commit & tag new version, pushing to existing git remote
+    5. For each deployment target specified in the project's config:
+      5.1. Run \`${cmd('aunty build')} ${opt('--id=<package.json:version> --target=<target_name>')}\`*
+      5.2. Run \`${cmd('aunty deploy')} ${opt('--id=<package.json:version> --target=<target_name>')}\`
+    
+    * Uses existing build (3) for first deploy target
 
-  ${cmd('aunty release --bump=major')}
-    For each deployment target specified in the project's config:
-      1. Check for uncommitted local changes (exiting if any exist)
-      2. Bump the major version in ${hvy('package.json')} & commit, pushing it to any remotes
-      3. Run \`${cmd('aunty build')} ${opt('--target=<target_name> --id=<package.json:version>')}\`
-      4. Tag a release with ${hvy('git')} (using ${hvy('package.json:version')}), pushing it to any remotes
-      5. Run \`${cmd('aunty deploy')} ${opt('--target=<target_name> --id=<package.json:version>')}\`
-
+  ${cmd(`aunty release ${opt('--bump=major')}`)}
+    As above, skipping (2).
 
   ${cmd(`aunty release ${opt('--force')}`)}
-    For each deployment target specified in the project's config:
-      1. Run \`${cmd('aunty build')} ${opt('--target=<target_name> --id=<package.json:version>')}\`
-      2. Run \`${cmd('aunty deploy')} ${opt('--target=<target_name> --id=<package.json:version>')}\`
+    As above, skipping (1, 2 & 4).
 `
 };


### PR DESCRIPTION
Rather than requiring you perform manual bumping prior to releasing, or running `release` with the `--bump={major|minor|patch}` argument, bumping the version number is now an interactive step in the `release` command's process.

![example terminal session](https://giant.gfycat.com/BitterSizzlingBrownbear.gif)

You can still bypass this with the `--force` argument, if you want to override the existing version (just remember to manually flush Akamai's cache if you're doing this — I've been caught by this a few times in the past).

Also, `package-lock.json` now gets a version bump in sync with `package.json`. This has been wrong for a while, so it's nice to not have to think about it.

I've updated the `release` command's help text to match the new steps (and their execution order), and tweaked the `--dry` output.