### PR TITLE
New projects start with a prerelease version, and changelogs are printed to aid in post-1.0.0 bump selection.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2757,27 +2757,6 @@
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
     },
-    "bump-file": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/bump-file/-/bump-file-1.0.0.tgz",
-      "integrity": "sha512-mUN6TDIkvDmE6gNlgMDiLl95qcgfqQ5Hu8HZDFk4AW3t9xBcKoasHlMcjV+1C6jmRRX4G2WySML0JGauRzFKaw==",
-      "requires": {
-        "detect-indent": "5.0.0",
-        "semver": "5.4.1"
-      },
-      "dependencies": {
-        "detect-indent": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
-        },
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
-        }
-      }
-    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -4067,11 +4046,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/detect-conflict/-/detect-conflict-1.0.1.tgz",
       "integrity": "sha1-CIZXpmqWHAUBnbfEIwiDsca0F24="
-    },
-    "detect-indent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-      "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
     },
     "detect-newline": {
       "version": "2.1.0",
@@ -9841,49 +9815,6 @@
         "pinkie": "^2.0.0"
       }
     },
-    "pkg-dir": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-      "requires": {
-        "find-up": "^3.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
-          "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        }
-      }
-    },
     "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
@@ -14283,53 +14214,6 @@
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.2"
-      }
-    },
-    "write-json-file": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.3.0.tgz",
-      "integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
-      "requires": {
-        "detect-indent": "^5.0.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^1.0.0",
-        "pify": "^3.0.0",
-        "sort-keys": "^2.0.0",
-        "write-file-atomic": "^2.0.0"
-      },
-      "dependencies": {
-        "detect-indent": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
-        },
-        "sort-keys": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
-          "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-          "requires": {
-            "is-plain-obj": "^1.0.0"
-          }
-        }
-      }
-    },
-    "write-pkg": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-3.2.0.tgz",
-      "integrity": "sha512-tX2ifZ0YqEFOF1wjRW2Pk93NLsj02+n1UP5RvO6rCs0K6R2g1padvf006cY74PQJKMGS2r42NK7FD0dG6Y6paw==",
-      "requires": {
-        "sort-keys": "^2.0.0",
-        "write-json-file": "^2.2.0"
-      },
-      "dependencies": {
-        "sort-keys": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
-          "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-          "requires": {
-            "is-plain-obj": "^1.0.0"
-          }
-        }
       }
     },
     "ws": {

--- a/src/commands/release/constants.js
+++ b/src/commands/release/constants.js
@@ -23,7 +23,7 @@ module.exports.MESSAGES = {
 ${changelog.join('\n')}
 `
       : `${cmd('ℹ')} Nothing has changed since ${hvy(tag)}\n`,
-  createCommit: (from, to) => `Bump version ${hvy(from)} => ${hvy(to)}`,
+  createCommit: (from, to) => `Bump version ${hvy(from)} → ${hvy(to)}`,
   createTag: tag => `Create tag ${hvy(tag)}`,
   hasTag: (tag, isTagOnHead) =>
     `The tag ${hvy(tag)} already exists${

--- a/src/commands/release/constants.js
+++ b/src/commands/release/constants.js
@@ -16,6 +16,13 @@ module.exports.MESSAGES = {
   FORCE_REMINDER,
   HAS_CHANGES: `You shouldn't release builds which may contain un-committed changes! ${FORCE_REMINDER}`,
   NOT_REPO: `You can't tag a release or deploy using a tag name becase this project isn't a git repo.`,
+  changes: (tag, tags, changelog) =>
+    changelog.length
+      ? `${tags.length ? `Here's what's changed since ${hvy(tag)}` : 'Here are the initial changes'}:
+
+${changelog.join('\n')}
+`
+      : `${cmd('ℹ')} Nothing has changed since ${hvy(tag)}\n`,
   createBump: (bump, from, to) => `Bump ${hvy(bump)} version ${hvy(from)}=>${hvy(to)}`,
   createTag: tag => `Create tag ${hvy(tag)}`,
   hasTag: (tag, isTagOnHead) =>

--- a/src/commands/release/constants.js
+++ b/src/commands/release/constants.js
@@ -23,7 +23,7 @@ module.exports.MESSAGES = {
 ${changelog.join('\n')}
 `
       : `${cmd('ℹ')} Nothing has changed since ${hvy(tag)}\n`,
-  createCommit: (from, to) => `Bump version ${hvy(from)}=>${hvy(to)}`,
+  createCommit: (from, to) => `Bump version ${hvy(from)} => ${hvy(to)}`,
   createTag: tag => `Create tag ${hvy(tag)}`,
   hasTag: (tag, isTagOnHead) =>
     `The tag ${hvy(tag)} already exists${

--- a/src/commands/release/constants.js
+++ b/src/commands/release/constants.js
@@ -23,7 +23,7 @@ module.exports.MESSAGES = {
 ${changelog.join('\n')}
 `
       : `${cmd('ℹ')} Nothing has changed since ${hvy(tag)}\n`,
-  createBump: (bump, from, to) => `Bump ${hvy(bump)} version ${hvy(from)}=>${hvy(to)}`,
+  createCommit: (from, to) => `Bump version ${hvy(from)}=>${hvy(to)}`,
   createTag: tag => `Create tag ${hvy(tag)}`,
   hasTag: (tag, isTagOnHead) =>
     `The tag ${hvy(tag)} already exists${
@@ -32,7 +32,7 @@ ${changelog.join('\n')}
   invalidBump: bump =>
     `You supplied an invalid bump value ${hvy(bump)}. It can be: ${hvy(Array.from(VALID_BUMPS).join('|'))}`,
   invalidHead: label => `You are trying to release from ${hvy(label)}. You should only release from ${hvy('master')}`,
-  pushBump: remote => `Push bump to remote ${hvy(remote)}`,
+  pushCommit: remote => `Push version bump to remote ${hvy(remote)}`,
   pushTag: (tag, remote) => `Push tag ${hvy(tag)} to remote ${hvy(remote)}`,
   usage: name => `
 Usage: ${cmd(`aunty ${name}`)} ${opt('[options] [build_options] [deploy_options]')}

--- a/src/commands/release/index.js
+++ b/src/commands/release/index.js
@@ -13,8 +13,10 @@ const { bad, dim, opt } = require('../../utils/color');
 const {
   commitAll,
   createTag,
+  getChangelog,
   getCurrentLabel,
   getRemotes,
+  getTags,
   hasChanges,
   isRepo,
   push,
@@ -72,7 +74,9 @@ module.exports.release = command(
     let bump = !argv.force && VALID_BUMPS.has(argv.bump) && argv.bump;
 
     if (!argv.force && !bump) {
+      log(MESSAGES.changes(config.pkg.version, await getTags(), await getChangelog(config.pkg.version)));
       log(MESSAGES.BUMP_QUESTION);
+
       const bumpSelection = (await cliSelect({
         defaultValue: 0,
         selected: opt('❯'),

--- a/src/generators/app/templates/_common/package.json
+++ b/src/generators/app/templates/_common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "<%= projectSlug %>",
-  "version": "1.0.0",
+  "version": "1.0.0-pre",
   "description": "A project generated from aunty's <%= projectType %> app template.",
   "license": "MIT",
   "private": true,

--- a/src/utils/git.js
+++ b/src/utils/git.js
@@ -79,3 +79,13 @@ module.exports.getGithubVersion = async repo => {
 
   return p.version;
 };
+
+module.exports.getTags = async () => (await git('tag')).stdout.split('\n').filter(x => x);
+
+const hasTag = async tag => !(await pack(git(`show-ref --tags --verify refs/tags/${tag}`)))[0];
+
+module.exports.getChangelog = async tag =>
+  (await git(`log ${(await hasTag(tag)) ? `${tag}..HEAD ` : ''}--oneline --color`)).stdout
+    .split('\n')
+    .filter(x => x)
+    .reverse();


### PR DESCRIPTION
Initial `aunty release`:

```bash
⣾⢷⡾⢷⡾⣷ aunty
⢿⡾⢷⡾⢷⡿ release

✔ Clean
✔ Preflight
✔ Bump version 1.0.0-pre=>1.0.0
✔ Create tag 1.0.0
✔ Build
ℹ Deployment (ftp):
  ┣ from /Users/gourlayc4n/Documents/code/basic/build
  ┣ to   /www/res/sites/news-projects/basic/1.0.0
  ┗ on   contentftp.abc.net.au
✔ Deploy (3/3)
ℹ Public URL: http://www.abc.net.au/res/sites/news-projects/basic/1.0.0/
```

Subsequent release (after making one commit):

```bash
⣾⢷⡾⢷⡾⣷ aunty
⢿⡾⢷⡾⢷⡿ release

Here's what's changed since 1.0.0:

e803001 Updated package.json description

? What package version bump is this release?
❯ Patch (1.0.1)
  Minor (1.1.0)
  Major (2.0.0)

✔ Clean
✔ Preflight
✔ Bump version 1.0.0=>1.0.1
✔ Create tag 1.0.1
✔ Build
ℹ Deployment (ftp):
  ┣ from /Users/gourlayc4n/Documents/code/basic/build
  ┣ to   /www/res/sites/news-projects/basic/1.0.1
  ┗ on   contentftp.abc.net.au
✔ Deploy (3/3)
ℹ Public URL: http://www.abc.net.au/res/sites/news-projects/basic/1.0.1/
```