### PR TITLE
HTTPS by default for dev server

### DIFF
--- a/src/config/webpack.js
+++ b/src/config/webpack.js
@@ -243,6 +243,7 @@ async function createDevServerConfig(argv, config) {
     noInfo: true,
     overlay: true,
     quiet: true,
+    https: true,
     watchOptions: {
       ignored: /node_modules/
     },

--- a/src/config/webpack.js
+++ b/src/config/webpack.js
@@ -62,7 +62,9 @@ module.exports.createConfig = async (argv, config, isServer) => {
   if (isServer) {
     const devServerConfig = await createDevServerConfig(argv, config);
     webpackConfig.map(c => {
-      c.output.publicPath = devServerConfig.publicPath = `http://${devServerConfig.host}:${devServerConfig.port}/`;
+      c.output.publicPath = devServerConfig.publicPath = `http${devServerConfig.https ? 's' : ''}://${
+        devServerConfig.host
+      }:${devServerConfig.port}/`;
       if (devServerConfig.hot) {
         c.entry = upgradeEntryToHot(c.entry, c.output.publicPath);
         c.plugins.push(new webpack.HotModuleReplacementPlugin());


### PR DESCRIPTION
For the record I looked into doing something much more elaborate on this, generating persistent cert keys and providing instructions for trusting in your OS so you could avoid content warnings all together. In the end though it seems more sensible to leave that up to individuals to allow exceptions in-browser. 

I'm happy to take further input though. 