### PR TITLE
Switch to es6 module import syntax

### DIFF
--- a/src/generators/app/templates/basic/src/components/App/index.js
+++ b/src/generators/app/templates/basic/src/components/App/index.js
@@ -1,7 +1,7 @@
-const styles = require('./styles.scss');
-const worm = require('./worm.svg');
+import styles from './styles.scss';
+import worm from './worm.svg';
 
-function App({ projectName }) {
+export default function App({ projectName }) {
   this.el = document.createElement('div');
   this.el.className = styles.root;
   this.el.innerHTML = `
@@ -9,5 +9,3 @@ function App({ projectName }) {
     <h1>${projectName}</h1>
   `;
 }
-
-module.exports = App;

--- a/src/generators/app/templates/basic/src/components/App/index.test.js
+++ b/src/generators/app/templates/basic/src/components/App/index.test.js
@@ -1,4 +1,4 @@
-const App = require('.');
+import App from '.';
 
 test('it renders', () => {
   const component = new App({ projectName: 'test-project' });

--- a/src/generators/app/templates/basic/src/components/ErrorBox/index.js
+++ b/src/generators/app/templates/basic/src/components/ErrorBox/index.js
@@ -1,6 +1,6 @@
-const styles = require('./styles.css');
+import styles from './styles.css';
 
-function ErrorBox({ error }) {
+export default function ErrorBox({ error }) {
   const el = (this.el = document.createElement('pre'));
 
   el.className = styles.root;
@@ -14,5 +14,3 @@ function ErrorBox({ error }) {
     console.error(error);
   })();
 }
-
-module.exports = ErrorBox;

--- a/src/generators/app/templates/basic/src/index.js
+++ b/src/generators/app/templates/basic/src/index.js
@@ -2,7 +2,7 @@ const PROJECT_NAME = '<%= projectSlug %>';
 const root = document.querySelector(`[data-${PROJECT_NAME}-root]`);
 
 function init() {
-  const App = require('./components/App');
+  import App from './components/App';
   root.appendChild(new App({ projectName: PROJECT_NAME }).el);
 }
 
@@ -15,7 +15,7 @@ if (module.hot) {
     try {
       init();
     } catch (err) {
-      const ErrorBox = require('./components/ErrorBox');
+      import ErrorBox from './components/ErrorBox';
       root.appendChild(new ErrorBox({ error: err }).el);
     }
   });

--- a/src/generators/app/templates/preact/src/components/App/index.js
+++ b/src/generators/app/templates/preact/src/components/App/index.js
@@ -1,8 +1,8 @@
-const { h, Component } = require('preact');
-const styles = require('./styles.scss');
-const worm = require('./worm.svg');
+import { h, Component } from 'preact';
+import styles from './styles.scss';
+import worm from './worm.svg';
 
-class App extends Component {
+export default class App extends Component {
   render({ projectName }) {
     return (
       <div className={styles.root}>
@@ -12,5 +12,3 @@ class App extends Component {
     );
   }
 }
-
-module.exports = App;

--- a/src/generators/app/templates/preact/src/components/App/index.test.js
+++ b/src/generators/app/templates/preact/src/components/App/index.test.js
@@ -1,8 +1,8 @@
-const { h } = require('preact');
-const render = require('preact-render-to-string');
-const htmlLooksLike = require('html-looks-like');
+import { h }  from 'preact';
+import render from 'preact-render-to-string';
+import htmlLooksLike from 'html-looks-like';
 
-const App = require('.');
+import App from '.';
 
 describe('App', () => {
   test('It renders', () => {

--- a/src/generators/app/templates/preact/src/components/ErrorBox/index.js
+++ b/src/generators/app/templates/preact/src/components/ErrorBox/index.js
@@ -1,7 +1,7 @@
-const { h, Component } = require('preact');
-const styles = require('./styles.css');
+import { h, Component } from 'preact';
+import styles from './styles.css';
 
-class ErrorBox extends Component {
+export default class ErrorBox extends Component {
   componentDidMount() {
     console.error(this.props.error);
   }
@@ -10,5 +10,3 @@ class ErrorBox extends Component {
     return <pre className={styles.root}>{this.props.error.stack}</pre>;
   }
 }
-
-module.exports = ErrorBox;

--- a/src/generators/app/templates/preact/src/index.js
+++ b/src/generators/app/templates/preact/src/index.js
@@ -1,10 +1,10 @@
-const { h, render } = require('preact');
+import { h, render }  from 'preact';
 
 const PROJECT_NAME = '<%= projectSlug %>';
 const root = document.querySelector(`[data-${PROJECT_NAME}-root]`);
 
 function init() {
-  const App = require('./components/App');
+  import App from './components/App';
   render(<App projectName={PROJECT_NAME} />, root, root.firstChild);
 }
 
@@ -15,7 +15,7 @@ if (module.hot) {
     try {
       init();
     } catch (err) {
-      const ErrorBox = require('./components/ErrorBox');
+      import ErrorBox from './components/ErrorBox';
       render(<ErrorBox error={err} />, root, root.firstChild);
     }
   });

--- a/src/generators/app/templates/react/src/components/App/index.js
+++ b/src/generators/app/templates/react/src/components/App/index.js
@@ -1,8 +1,8 @@
-const React = require('react');
-const styles = require('./styles.scss');
-const worm = require('./worm.svg');
+import React from 'react';
+import styles from './styles.scss';
+import worm from './worm.svg';
 
-class App extends React.Component {
+export default class App extends React.Component {
   render() {
     return (
       <div className={styles.root}>
@@ -12,5 +12,3 @@ class App extends React.Component {
     );
   }
 }
-
-module.exports = App;

--- a/src/generators/app/templates/react/src/components/App/index.test.js
+++ b/src/generators/app/templates/react/src/components/App/index.test.js
@@ -1,7 +1,7 @@
-const React = require('react');
-const renderer = require('react-test-renderer');
+import React from 'react';
+import renderer from 'react-test-renderer';
 
-const App = require('.');
+import App from '.';
 
 describe('App', () => {
   test('It renders', () => {

--- a/src/generators/app/templates/react/src/components/ErrorBox/index.js
+++ b/src/generators/app/templates/react/src/components/ErrorBox/index.js
@@ -1,7 +1,7 @@
-const React = require('react');
-const styles = require('./styles.css');
+import React from 'react';
+import styles from './styles.css';
 
-class ErrorBox extends React.Component {
+export default class ErrorBox extends React.Component {
   componentDidMount() {
     console.error(this.props.error);
   }
@@ -10,5 +10,3 @@ class ErrorBox extends React.Component {
     return <pre className={styles.root}>{this.props.error.stack}</pre>;
   }
 }
-
-module.exports = ErrorBox;

--- a/src/generators/app/templates/react/src/index.js
+++ b/src/generators/app/templates/react/src/index.js
@@ -1,11 +1,11 @@
-const React = require('react');
-const { render } = require('react-dom');
+import React from 'react';
+import { render }  from 'react-dom';
 
 const PROJECT_NAME = '<%= projectSlug %>';
 const root = document.querySelector(`[data-${PROJECT_NAME}-root]`);
 
 function init() {
-  const App = require('./components/App');
+  import App from './components/App';
   render(<App projectName={PROJECT_NAME} />, root);
 }
 
@@ -16,7 +16,7 @@ if (module.hot) {
     try {
       init();
     } catch (err) {
-      const ErrorBox = require('./components/ErrorBox');
+      import ErrorBox from './components/ErrorBox';
       render(<ErrorBox error={err} />, root);
     }
   });

--- a/src/generators/component/templates/basic/component-with-d3.js
+++ b/src/generators/component/templates/basic/component-with-d3.js
@@ -1,8 +1,8 @@
-const d3 = require('d3-selection');
+import d3 from 'd3-selection';
 
-const styles = require('./styles.scss');
+import styles from './styles.scss';
 
-function <%= className %>() {
+export default function <%= className %>() {
   this.el = document.createElement('div');
   this.el.className = styles.wrapper;
   
@@ -23,5 +23,3 @@ function <%= className %>() {
     .attr('width', 400)
     .attr('height', 300);
 }
-
-module.exports = <%= className %>;

--- a/src/generators/component/templates/basic/component-with-d3.test.js
+++ b/src/generators/component/templates/basic/component-with-d3.test.js
@@ -1,4 +1,4 @@
-const <%= className %> = require('.');
+import <%= className %> from '.';
 
 test('it renders', () => {
   const component = new <%= className %>();

--- a/src/generators/component/templates/basic/component.js
+++ b/src/generators/component/templates/basic/component.js
@@ -1,4 +1,4 @@
-const styles = require('./styles.scss');
+import styles from './styles.scss';
 
 function <%= className %>() {
   this.el = document.createElement('div');
@@ -6,4 +6,4 @@ function <%= className %>() {
   this.el.innerHTML = `Find me in src/components/<%= className %>/index.js`;
 }
 
-module.exports = <%= className %>;
+export <%= className %>;

--- a/src/generators/component/templates/basic/component.test.js
+++ b/src/generators/component/templates/basic/component.test.js
@@ -1,4 +1,4 @@
-const <%= className %> = require('.');
+import <%= className %> from '.';
 
 test('it renders', () => {
   const component = new <%= className %>();

--- a/src/generators/component/templates/preact/component-with-d3.js
+++ b/src/generators/component/templates/preact/component-with-d3.js
@@ -1,9 +1,9 @@
-const { h, Component } = require('preact');
-const d3 = require('d3-selection');
+import { h, Component }  from 'preact';
+import d3 from 'd3-selection';
 
-const styles = require('./styles.scss');
+import styles from './styles.scss';
 
-class <%= className %> extends Component {
+export default class <%= className %> extends Component {
   constructor(props) {
     super(props);
 
@@ -69,5 +69,3 @@ class <%= className %> extends Component {
     return <div className={styles.wrapper} />;
   }
 }
-
-module.exports = <%= className %>;

--- a/src/generators/component/templates/preact/component-with-d3.test.js
+++ b/src/generators/component/templates/preact/component-with-d3.test.js
@@ -1,8 +1,8 @@
-const { h } = require('preact');
-const render = require('preact-render-to-string');
-const htmlLooksLike = require('html-looks-like');
+import { h }  from 'preact';
+import render from 'preact-render-to-string';
+import htmlLooksLike from 'html-looks-like';
 
-const <%= className %> = require('.');
+import <%= className %> from '.';
 
 describe('<%= className %>', () => {
   test('It renders', () => {

--- a/src/generators/component/templates/preact/component.js
+++ b/src/generators/component/templates/preact/component.js
@@ -1,8 +1,8 @@
-const { h, Component } = require('preact');
+import { h, Component }  from 'preact';
 
-const styles = require('./styles.scss');
+import styles from './styles.scss';
 
-class <%= className %> extends Component {
+export default class <%= className %> extends Component {
   render() {
     return (
       <div className={styles.wrapper}>
@@ -11,5 +11,3 @@ class <%= className %> extends Component {
     );
   }
 }
-
-module.exports = <%= className %>;

--- a/src/generators/component/templates/preact/component.test.js
+++ b/src/generators/component/templates/preact/component.test.js
@@ -1,8 +1,8 @@
-const { h } = require('preact');
-const render = require('preact-render-to-string');
-const htmlLooksLike = require('html-looks-like');
+import { h }  from 'preact';
+import render from 'preact-render-to-string';
+import htmlLooksLike from 'html-looks-like';
 
-const <%= className %> = require('.');
+import <%= className %> from '.';
 
 describe('<%= className %>', () => {
   test('It renders', () => {

--- a/src/generators/component/templates/react/component-with-d3.js
+++ b/src/generators/component/templates/react/component-with-d3.js
@@ -1,9 +1,9 @@
-const React = require('react');
-const d3 = require('d3-selection');
+import React from 'react';
+import d3 from 'd3-selection';
 
-const styles = require('./styles.scss');
+import styles from './styles.scss';
 
-class <%= className %> extends React.Component {
+export default class <%= className %> extends React.Component {
   constructor(props) {
     super(props);
 
@@ -73,5 +73,3 @@ class <%= className %> extends React.Component {
     return <div className={styles.wrapper} ref={el => (this.wrapper = el)} />;
   }
 }
-
-module.exports = <%= className %>;

--- a/src/generators/component/templates/react/component-with-d3.test.js
+++ b/src/generators/component/templates/react/component-with-d3.test.js
@@ -1,7 +1,7 @@
-const React = require('react');
-const renderer = require('react-test-renderer');
+import React from 'react';
+import renderer from 'react-test-renderer';
 
-const <%= className %> = require('.');
+import <%= className %> from '.';
 
 describe('<%= className %>', () => {
   test('It renders', () => {

--- a/src/generators/component/templates/react/component.js
+++ b/src/generators/component/templates/react/component.js
@@ -1,7 +1,7 @@
-const React = require('react');
-const styles = require('./styles.scss');
+import React from 'react';
+import styles from './styles.scss';
 
-class <%= className %> extends React.Component {
+export default class <%= className %> extends React.Component {
   render() {
     return (
       <div className={styles.wrapper}>
@@ -10,5 +10,3 @@ class <%= className %> extends React.Component {
     );
   }
 }
-
-module.exports = <%= className %>;

--- a/src/generators/component/templates/react/component.test.js
+++ b/src/generators/component/templates/react/component.test.js
@@ -1,7 +1,7 @@
-const React = require('react');
-const renderer = require('react-test-renderer');
+import React from 'react';
+import renderer from 'react-test-renderer';
 
-const <%= className %> = require('.');
+import <%= className %> from '.';
 
 describe('<%= className %>', () => {
   test('It renders', () => {


### PR DESCRIPTION
This is just a first pass at switching the template files to es6 module import syntax for discussion.

There are probably issues I haven't thought of. Also we might want to make these an option behind a flag rather than wholesale replace. That would, for example, allow continued use of the component generator on older projects with an upgraded aunty. 

I'm keen to make this switch if we can.