### PR TITLE
Just camelise component names

### DIFF
--- a/src/generators/component/index.js
+++ b/src/generators/component/index.js
@@ -88,7 +88,7 @@ module.exports = class extends Generator {
       this.options = combine(this.options, answers);
     }
 
-    this.options.name = Inflect.classify(this.options.name.replace(' ', '_'));
+    this.options.name = Inflect.camelize(this.options.name.replace(' ', '_'));
     this.config.set('template', this.options.template);
   }
 


### PR DESCRIPTION
The `singularize` method in the `i` package does little more than trim trailing `"s"` characters, which leads to incorrect component & file names when the `component` generator runs.

Using `camelize` directly instead of `classify`, removes `singularize` from the transform, and puts a little more responsibility on the author, but I think this is ultimately better.

Closes #86 