### PR TITLE
Extending webpack dev server config

### DIFF
--- a/src/config/webpackDevServer.js
+++ b/src/config/webpackDevServer.js
@@ -4,7 +4,7 @@ const { getProjectConfig } = require('./project');
 const { getServeConfig } = require('./serve');
 
 module.exports.getWebpackDevServerConfig = () => {
-  const { webpackDevServer: projectWebpackDevServerConfig } = getProjectConfig();
+  const { devServer } = getProjectConfig();
   const { host, hot, https, port } = getServeConfig();
 
   return combine(
@@ -23,6 +23,6 @@ module.exports.getWebpackDevServerConfig = () => {
         ignored: /node_modules/
       }
     },
-    projectWebpackDevServerConfig
+    devServer
   );
 };


### PR DESCRIPTION
Unless I've missed something, the big ol' config refactor in b9c6cb4f516079552aad999f62fb4b908e811e0c broke (changed?) how webpack dev server config is extended.

Previously, it was possible to extend it with the following `aunty.config.js`:

```
module.exports = {
  type: "react",
  devServer: {
    after: require("./server")
  }
};
```

That nolonger seems to be possible, this change fixes that.

There is a related but different issue which might be considered a bug  specifically around the HTTPS setting in the dev server config. If you change it by doing:

```
module.exports = {
  serve: {
    https: false
  }
};
```

everything will work as expected. But if you change it using the `devServer` key this change re-enables, the change to HTTPS will be effective, but the `publicPath` will be incorrect.