### PR TITLE
Downgrade tcp-ping-sync so it doesn't try to use netlinkwrapper for probing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2083,12 +2083,6 @@
       "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.1.2.tgz",
       "integrity": "sha512-xVNN69YGDghOqCCtA6FI7avYrr02mTJjOgB0/f1VPD3pJC8QEvjTKWc4epDx8AqxxA75NI0QpVM2gPJXUbE4Tg=="
     },
-    "bindings": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==",
-      "optional": true
-    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -8453,24 +8447,6 @@
       "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.0.1.tgz",
       "integrity": "sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A=="
     },
-    "netlinkwrapper": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/netlinkwrapper/-/netlinkwrapper-1.1.1.tgz",
-      "integrity": "sha512-upMFuUEwE7XFrHALa3F75O140mN2aYeZCr5erR5saz35hQ0q+SQWOQlk/0aQW/qRSLt3cb4GDk4FiesFYcyNTA==",
-      "optional": true,
-      "requires": {
-        "bindings": "1.3.0",
-        "nan": "2.11.0"
-      },
-      "dependencies": {
-        "nan": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
-          "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
-          "optional": true
-        }
-      }
-    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -12069,11 +12045,10 @@
       }
     },
     "tcp-ping-sync": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tcp-ping-sync/-/tcp-ping-sync-2.0.0.tgz",
-      "integrity": "sha512-y+EKtS/21xcmG2vfGN2j4GHA7ZS6FcusuUie4Yy6auuMxa3XxRMMOqY7k+nnA0XdkyPVa91D4DFso34MEDcYPg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tcp-ping-sync/-/tcp-ping-sync-1.0.0.tgz",
+      "integrity": "sha512-o4d3AyDNNcAMo1fXjyu2537W496dCxFDkd3TWPgbKdUOJjkxPJueH3bIaSqLXO1yG4bjp9TfFnyoAtjWLmqKWA==",
       "requires": {
-        "netlinkwrapper": "^1.1.1",
         "sync-socket": "^1.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "sass-loader": "^6.0.7",
     "semver": "^5.6.0",
     "style-loader": "^0.18.2",
-    "tcp-ping-sync": "^2.0.0",
+    "tcp-ping-sync": "^1.0.0",
     "uglifyjs-webpack-plugin": "^1.3.0",
     "update-notifier": "^2.5.0",
     "url-loader": "^1.1.1",


### PR DESCRIPTION
This was the cause of intermittent segfaults when starting the development server.

Closes #89 