### PR TITLE
Add new `aunty sign-cert` command to create SSL certificates for `aunty serve`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3029,6 +3029,16 @@
         "unique-string": "^1.0.0",
         "write-file-atomic": "^2.0.0",
         "xdg-basedir": "^3.0.0"
+      },
+      "dependencies": {
+        "make-dir": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        }
       }
     },
     "connect-history-api-fallback": {
@@ -3131,6 +3141,16 @@
             "commondir": "^1.0.1",
             "make-dir": "^1.0.0",
             "pkg-dir": "^2.0.0"
+          },
+          "dependencies": {
+            "make-dir": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+              "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+              "requires": {
+                "pify": "^3.0.0"
+              }
+            }
           }
         },
         "is-extglob": {
@@ -4894,6 +4914,16 @@
         "commondir": "^1.0.1",
         "make-dir": "^1.0.0",
         "pkg-dir": "^3.0.0"
+      },
+      "dependencies": {
+        "make-dir": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        }
       }
     },
     "find-up": {
@@ -7953,11 +7983,18 @@
       }
     },
     "make-dir": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
+      "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
       "requires": {
-        "pify": "^3.0.0"
+        "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
+          "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ=="
+        }
       }
     },
     "makeerror": {
@@ -12469,6 +12506,16 @@
             "commondir": "^1.0.1",
             "make-dir": "^1.0.0",
             "pkg-dir": "^2.0.0"
+          },
+          "dependencies": {
+            "make-dir": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+              "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+              "requires": {
+                "pify": "^3.0.0"
+              }
+            }
           }
         },
         "pkg-dir": {
@@ -13713,6 +13760,21 @@
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
           "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
         },
+        "make-dir": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+          "requires": {
+            "pify": "^3.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+            }
+          }
+        },
         "pify": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -13941,6 +14003,14 @@
           "requires": {
             "p-locate": "^3.0.0",
             "path-exists": "^3.0.0"
+          }
+        },
+        "make-dir": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+          "requires": {
+            "pify": "^3.0.0"
           }
         },
         "p-limit": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "jsonfile-updater": "^3.1.0",
     "load-json-file": "^2.0.0",
     "log-symbols": "^2.2.0",
+    "make-dir": "^3.0.0",
     "mem": "^4.0.0",
     "mini-css-extract-plugin": "^0.5.0",
     "minimist": "^1.2.0",

--- a/src/cli/constants.js
+++ b/src/cli/constants.js
@@ -10,6 +10,7 @@ const COMMAND_ALIASES = (module.exports.COMMAND_ALIASES = {
   g: 'generate',
   r: 'release',
   s: 'serve',
+  sc: 'sign-cert',
   t: 'test'
 });
 
@@ -97,6 +98,9 @@ ${sec('Helper commands')}
 
   ${cmd('aunty help')} ${req('<command>')}
     Display complete help for this ${req('command')}.
+  
+  ${cmd('aunty sign-cert')} # Mac OS only (for now)
+    Create a consistent SSL certificate for the dev server
 `
 };
 

--- a/src/cli/sign-cert/constants.js
+++ b/src/cli/sign-cert/constants.js
@@ -1,0 +1,42 @@
+// Ours
+const { cmd, opt, sec } = require('../../utils/color');
+
+module.exports.MESSAGES = {
+  opensslArgs: (host, keyout, out) => [
+    'req',
+    '-newkey',
+    'rsa:2048',
+    '-x509',
+    '-nodes',
+    '-keyout',
+    keyout,
+    '-new',
+    '-out',
+    out,
+    '-subj',
+    `/CN=${host}`,
+    '-reqexts',
+    'SAN',
+    '-extensions',
+    'SAN',
+    '-config',
+    `<(cat /System/Library/OpenSSL/openssl.cnf <(printf '[SAN]\nsubjectAltName=DNS:${host}'))`,
+    '-sha256',
+    '-days',
+    '3650'
+  ],
+  manual: path => `You should install this certificate in your Mac OS Keychain:
+    ${path}
+`,
+  platform: `Sorry, this command is only supported on MacOS (for now)`,
+  usage: name => `Usage: ${cmd(`aunty ${name}`)} ${opt('[options]')}
+
+${sec('Options')}
+
+  ${opt('-d')}, ${opt('--dry')} Output the assumed host, file paths & openssl command that would have run, then exit
+
+${sec('Environment variables')}
+
+  • You can override the host the certificate would be generated for by setting ${cmd('AUNTY_HOST')}
+`
+};

--- a/src/cli/sign-cert/index.js
+++ b/src/cli/sign-cert/index.js
@@ -1,0 +1,51 @@
+// Native
+const { spawnSync } = require('child_process');
+
+// External
+const importLazy = require('import-lazy')(require);
+const makeDir = importLazy('make-dir');
+
+// Ours
+const { DEFAULT_HOST, SERVER_CERT_FILENAME, SERVER_KEY_FILENAME, getSSLPath } = require('../../config/serve');
+const { hvy } = require('../../utils/color');
+const { dry, info, spin } = require('../../utils/logging');
+const { command } = require('../');
+const { MESSAGES } = require('./constants');
+
+module.exports = command(
+  {
+    name: 'sign-cert',
+    usage: MESSAGES.usage
+  },
+  async argv => {
+    if (process.platform !== 'darwin') {
+      throw new Error(MESSAGES.platform);
+    }
+
+    const host = process.env.AUNTY_HOST || DEFAULT_HOST;
+    const files = {
+      cert: getSSLPath(host, SERVER_CERT_FILENAME),
+      key: getSSLPath(host, SERVER_KEY_FILENAME)
+    };
+    const opensslArgs = MESSAGES.opensslArgs(host, files.key, files.cert);
+    const cmd = `openssl ${opensslArgs.join(' ')}`;
+
+    if (argv.dry) {
+      return dry({
+        'OpenSSL config': {
+          host,
+          files,
+          cmd
+        }
+      });
+    }
+
+    let spinner = spin(`Creating SSL certificate`);
+
+    await makeDir(getSSLPath(host));
+    spawnSync('bash', ['-c', cmd]);
+
+    spinner.succeed('SSL certificate created');
+    info(MESSAGES.manual(files.cert));
+  }
+);

--- a/src/config/serve.js
+++ b/src/config/serve.js
@@ -1,5 +1,7 @@
 // Native
-const { hostname } = require('os');
+const { homedir, hostname } = require('os');
+const { readFileSync } = require('fs');
+const { join } = require('path');
 
 // External
 const { probe } = require('tcp-ping-sync');
@@ -8,14 +10,18 @@ const { probe } = require('tcp-ping-sync');
 const { combine } = require('../utils/structures');
 const { getProjectConfig } = require('./project');
 
+const HOME_DIR = homedir();
+const SSL_DIR = '.aunty/ssl';
+const SERVER_CERT_FILENAME = (module.exports.SERVER_CERT_FILENAME = 'server.crt');
+const SERVER_KEY_FILENAME = (module.exports.SERVER_KEY_FILENAME = 'server.key');
 const INTERNAL_SUFFIX = '.aus.aunty.abc.net.au';
-const DEFAULT_HOST = probe(`nucwed${INTERNAL_SUFFIX}`)
+const DEFAULT_HOST = (module.exports.DEFAULT_HOST = probe(`nucwed${INTERNAL_SUFFIX}`)
   ? `${
       hostname()
         .toLowerCase()
         .split('.')[0]
     }${INTERNAL_SUFFIX}` // hostname _may_ include INTERNAL_SUFFIX
-  : 'localhost';
+  : 'localhost');
 const DEFAULT_PORT = 8000;
 
 module.exports.getServeConfig = () => {
@@ -29,7 +35,8 @@ module.exports.getServeConfig = () => {
       port: DEFAULT_PORT
     },
     serve,
-    addEnvironmentVariables
+    addEnvironmentVariables,
+    addUserSSLConfig
   );
 };
 
@@ -44,3 +51,22 @@ const addEnvironmentVariables = config => {
 
   return config;
 };
+
+const getSSLPath = (module.exports.getSSLPath = (host, name) => join(HOME_DIR, SSL_DIR, host, name || '.'));
+
+/*
+Set config.https to cert & key generated with `aunty sign-cert` (if they both exist)  
+We expect them to be in: ~/.aunty/ssl/<host>/server.{cert|key}
+*/
+function addUserSSLConfig(config) {
+  if (config.https === true) {
+    try {
+      config.https = {
+        cert: readFileSync(getSSLPath(config.host, SERVER_CERT_FILENAME)),
+        key: readFileSync(getSSLPath(config.host, SERVER_KEY_FILENAME))
+      };
+    } catch (e) {}
+  }
+
+  return config;
+}


### PR DESCRIPTION
* Certificates for the dev server's hostname (configurable) are stored in the user's `~/.aunty` directory.
* You should then manually add them to your Mac OS keychain
* `aunty serve` will use this certificate if it exists when running with https enabled (default).
* Now you'll only have to accept the cert once per browser, every 10 years

**Note**: This only works on Mac OS, if `openssl` is installed