### PR TITLE
Make bundle analyzer server port dynamic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4566,8 +4566,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4585,13 +4584,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4604,18 +4601,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4718,8 +4712,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4729,7 +4722,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4742,20 +4734,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4772,7 +4761,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4845,8 +4833,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4856,7 +4843,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4932,8 +4918,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4963,7 +4948,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4981,7 +4965,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5020,13 +5003,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/src/cli/serve/constants.js
+++ b/src/cli/serve/constants.js
@@ -1,17 +1,17 @@
 // Ours
 const { cmd, hvy, opt, sec } = require('../../utils/color');
 
-const BUNDLE_ANALYSER_CONFIG = (module.exports.BUNDLE_ANALYSER_CONFIG = {
+const BUNDLE_ANALYZER_CONFIG = (module.exports.BUNDLE_ANALYZER_CONFIG = {
   analyzerHost: '127.0.0.1',
-  analyzerPort: 8888,
   logLevel: 'warn',
   openAnalyzer: false
 });
 
 module.exports.MESSAGES = {
-  serve: ({ hot, publicPath }) => `Serve (${hvy(process.env.NODE_ENV)}):
+  analysis: ({ analyzerHost, analyzerPort }) => `http://${analyzerHost}:${analyzerPort}`,
+  serve: ({ hot, publicPath, bundleAnalysisPath }) => `Serve (${hvy(process.env.NODE_ENV)}):
   ┣ ${hvy('hot')}: ${cmd(hot ? 'yes' : 'no')}
-  ┣ ${hvy('bundle analysis')}: http://${BUNDLE_ANALYSER_CONFIG.analyzerHost}:${BUNDLE_ANALYSER_CONFIG.analyzerPort}
+  ┣ ${hvy('bundle analysis')}: ${bundleAnalysisPath}
   ┗ ${hvy('publicPath')}: ${publicPath}`,
   // TODO: Add aunty config section to usage
   usage: name => `Usage: ${cmd(`aunty ${name}`)} ${opt('[options]')}


### PR DESCRIPTION
Change: ensure bundle analyzer ports are unique by basing them on the server port, so multiple project dev servers can run without conflict.

Previously, the bundle analyzer port is `8888` + the index of the webpack config (usually there's only one). If you try to start a second aunty project's dev server on an alternative port, it blows up because the bundle analyzer port clashes with the first project.