### PR TITLE
Use unique webpack jsonp function names per-project

### DIFF
--- a/src/config/webpack.js
+++ b/src/config/webpack.js
@@ -82,7 +82,7 @@ module.exports.getWebpackConfig = () => {
 };
 
 function createWebpackConfig({ isModernJS } = {}) {
-  const { root, type, webpack: projectWebpackConfig } = getProjectConfig();
+  const { pkg, root, type, webpack: projectWebpackConfig } = getProjectConfig();
   const { entry, extractCSS, from, staticDir, to, useCSSModules } = getBuildConfig();
   const isProd = process.env.NODE_ENV === 'production';
 
@@ -97,6 +97,7 @@ function createWebpackConfig({ isModernJS } = {}) {
         path: join(root, to),
         publicPath: '/',
         filename: isModernJS ? '[name]_modern.js' : '[name].js',
+        jsonpFunction: `webpackJsonp__${pkg.name.replace(/[^a-z]/g, '_')}`,
         // The update file hash was causing 404s and full page reloads.
         // This will make the file name more predictable.
         // See https://github.com/webpack/webpack-dev-server/issues/79#issuecomment-244596129


### PR DESCRIPTION
Webpack uses jsonp to track its dynamic loading of chunks in multi-file packages, and by default uses the same [global function name](https://webpack.js.org/configuration/output/#outputjsonpfunction) for its callback.

This creates problems when multiple webpack-built multi-file projects are running in the same page (for example, Presentation Layer + Odyssey). All projects that execute after the first are unable to let webpack know that their chunks have loaded because their status updates to the first app (which is unaware of other projects).

This change to aunty's default webpack config factors the package name into the jsonp function name, which _should_ ensure that apps don't step on each others toes, and get all the callbacks they expect.