### PR TITLE
Make style rule hashes more specific

### DIFF
--- a/src/config/webpack.js
+++ b/src/config/webpack.js
@@ -153,7 +153,8 @@ function createWebpackConfig({ isModernJS } = {}) {
                   modules: useCSSModules && {
                     context: __dirname,
                     //  ^^^ https://github.com/webpack-contrib/css-loader/issues/413#issuecomment-299578180
-                    localIdentName: `${isProd ? '' : '[folder]-[name]__[local]-'}[hash:base64:6]`
+                    localIdentName: `${isProd ? '' : '[folder]-[name]__[local]-'}[hash:base64:6]`,
+                    hashPrefix: `${pkg.name}@${pkg.version}`
                   },
                   sourceMap: !isProd
                 }


### PR DESCRIPTION
I was getting clashes on prod between separate projects for the style rule hashes. This should bundle the project name and version into the hash so it will never clash.