### PR TITLE
Add source maps to all builds

### DIFF
--- a/src/config/webpack.js
+++ b/src/config/webpack.js
@@ -117,6 +117,7 @@ function createWebpackConfig({ isModernJS } = {}) {
       entry: {
         index: [join(root, from, entry)]
       },
+      devtool: "source-map",
       output: {
         path: join(root, to),
         publicPath: '/',


### PR DESCRIPTION
I don't see any reason not to have source maps on all builds.