### PR TITLE
Don't assume an aunty project repo's default branch is called master

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ npm unlink
 
 ## Releasing new versions of `@abcnews/aunty`
 
-Releases are managed by `release-it`. To release a new version of aunty from the project's default branch, run:
+Releases are managed by `release-it`. To release a new version of aunty from the default branch, run:
 
 ```
 npm run release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ npm unlink
 
 ## Releasing new versions of `@abcnews/aunty`
 
-Releases are managed by `release-it`. To release a new version of aunty from `master`, run:
+Releases are managed by `release-it`. To release a new version of aunty from the project's default branch, run:
 
 ```
 npm run release

--- a/src/cli/release/constants.js
+++ b/src/cli/release/constants.js
@@ -31,7 +31,8 @@ ${changelog.join('\n')}
     }! ${FORCE_REMINDER}`,
   invalidBump: bump =>
     `You supplied an invalid bump value ${hvy(bump)}. It can be: ${hvy(Array.from(VALID_BUMPS).join('|'))}`,
-  invalidHead: label => `You are trying to release from ${hvy(label)}. You should only release from ${hvy('master')}`,
+  notDefaultBranch: (label, defaultBranch) =>
+    `You are trying to release from ${hvy(label)}. You should only release from ${hvy(defaultBranch)}`,
   notRepo: `You can't tag a release or deploy using a tag name becase this project isn't a git repo.`,
   pushCommit: remote => `Push version bump to remote ${hvy(remote)}`,
   pushTag: (tag, remote) => `Push tag ${hvy(tag)} to remote ${hvy(remote)}`,

--- a/src/cli/release/index.js
+++ b/src/cli/release/index.js
@@ -53,7 +53,7 @@ module.exports = command(
     // 2) Ensure the defaullt branch is checked out (skippable)
 
     const label = await getCurrentLabel();
-    const defaultBranch = await getDefaultBranch();
+    const defaultBranch = await getDefaultBranch(remote);
 
     if (!argv.force && label !== defaultBranch) {
       throw MESSAGES.notDefaultBranch(label, defaultBranch);

--- a/src/cli/release/index.js
+++ b/src/cli/release/index.js
@@ -50,7 +50,7 @@ module.exports = command(
     const remotes = await getRemotes();
     const remote = argv['git-remote'];
 
-    // 2) Ensure the defaullt branch is checked out (skippable)
+    // 2) Ensure the default branch is checked out (skippable)
 
     const label = await getCurrentLabel();
     const defaultBranch = await getDefaultBranch(remote);

--- a/src/cli/release/index.js
+++ b/src/cli/release/index.js
@@ -17,6 +17,7 @@ const {
   createTag,
   getChangelog,
   getCurrentLabel,
+  getDefaultBranch,
   getRemotes,
   getSemverTags,
   hasChanges,
@@ -49,12 +50,13 @@ module.exports = command(
     const remotes = await getRemotes();
     const remote = argv['git-remote'];
 
-    // 2) Ensure the master branch is checked out (skippable)
+    // 2) Ensure the defaullt branch is checked out (skippable)
 
     const label = await getCurrentLabel();
+    const defaultBranch = await getDefaultBranch();
 
-    if (!argv.force && label !== 'master') {
-      throw MESSAGES.invalidHead(label);
+    if (!argv.force && label !== defaultBranch) {
+      throw MESSAGES.notDefaultBranch(label, defaultBranch);
     }
 
     // 3) Ensure the project no un-committed changes (skippable)
@@ -77,16 +79,18 @@ module.exports = command(
       log(MESSAGES.changes(pkgVersion, await getSemverTags(), await getChangelog(pkgVersion)));
       log(MESSAGES.bumpQuestion(argv.dry));
 
-      const bumpSelection = (await cliSelect({
-        defaultValue: 0,
-        selected: opt('❯'),
-        unselected: ' ',
-        values: [...VALID_BUMPS].reverse().map(bump => ({
-          bump,
-          label: `${bump.replace(/^\w/, c => c.toUpperCase())} (${semver.inc(pkgVersion, bump)})`
-        })),
-        valueRenderer: ({ label }, selected) => (selected ? opt(label) : label)
-      })).value;
+      const bumpSelection = (
+        await cliSelect({
+          defaultValue: 0,
+          selected: opt('❯'),
+          unselected: ' ',
+          values: [...VALID_BUMPS].reverse().map(bump => ({
+            bump,
+            label: `${bump.replace(/^\w/, c => c.toUpperCase())} (${semver.inc(pkgVersion, bump)})`
+          })),
+          valueRenderer: ({ label }, selected) => (selected ? opt(label) : label)
+        })
+      ).value;
       bump = bumpSelection.bump;
       log(`${dim(bumpSelection.label)}\n`);
     }

--- a/src/generators/articles/index.js
+++ b/src/generators/articles/index.js
@@ -65,11 +65,13 @@ module.exports = class extends Generator {
       dateString: date.toString(),
       dateISOString: date.toISOString(),
       authorName: this.user.git.name(),
-      odysseyVersion: this.plugins.includes('odyssey') ? await getGithubVersion('abcnews/odyssey') : false,
+      odysseyVersion: this.plugins.includes('odyssey') ? await getGithubVersion('abcnews/odyssey', 'master') : false,
       scrollytellerVersion: this.plugins.includes('scrollyteller')
-        ? await getGithubVersion('abcnews/odyssey-scrollyteller')
+        ? await getGithubVersion('abcnews/odyssey-scrollyteller', 'master')
         : false,
-      parallaxVersion: this.plugins.includes('parallax') ? await getGithubVersion('abcnews/odyssey-parallax') : false,
+      parallaxVersion: this.plugins.includes('parallax')
+        ? await getGithubVersion('abcnews/odyssey-parallax', 'master')
+        : false,
       desktopFragment: indented(fragment, 16),
       mobileFragment: indented(fragment, 12)
     };

--- a/src/utils/git.js
+++ b/src/utils/git.js
@@ -74,20 +74,16 @@ module.exports.createRepo = async cwd => {
 /**
  * Look up the current master version of a thing
  */
-module.exports.getGithubVersion = async repo => {
+module.exports.getGithubVersion = async (repo, defaultBranch) => {
   const spinner = spin(`Fetching latest version of ${repo}`);
-  const p = await fetch(`https://raw.githubusercontent.com/${repo}/master/package.json`).then(r => r.json());
+  const p = await fetch(`https://raw.githubusercontent.com/${repo}/${defaultBranch}/package.json`).then(r => r.json());
 
   spinner.stop();
 
   return p.version;
 };
 
-module.exports.getSemverTags = async () =>
-  (await git('tag')).stdout
-    .split('\n')
-    .filter(valid)
-    .sort(compare);
+module.exports.getSemverTags = async () => (await git('tag')).stdout.split('\n').filter(valid).sort(compare);
 
 const hasTag = async tag => !(await pack(git(`show-ref --tags --verify refs/tags/${tag}`)))[0];
 

--- a/src/utils/git.js
+++ b/src/utils/git.js
@@ -72,7 +72,7 @@ module.exports.createRepo = async cwd => {
 };
 
 /**
- * Look up the current master version of a thing
+ * Look up the current package.json version of a repo's default branch
  */
 module.exports.getGithubVersion = async (repo, defaultBranch) => {
   const spinner = spin(`Fetching latest version of ${repo}`);
@@ -81,6 +81,10 @@ module.exports.getGithubVersion = async (repo, defaultBranch) => {
   spinner.stop();
 
   return p.version;
+};
+
+module.exports.getDefaultBranch = async () => {
+  return 'master';
 };
 
 module.exports.getSemverTags = async () => (await git('tag')).stdout.split('\n').filter(valid).sort(compare);

--- a/src/utils/git.js
+++ b/src/utils/git.js
@@ -92,7 +92,7 @@ module.exports.getDefaultBranch = async remote => {
   let localDefaultBranch;
 
   if (remotes.has(remote)) {
-    // If we have a valid remote, find out which local branch confured to pull from the remote default branch
+    // If we have a valid remote, find out which local branch is configured to pull from the remote default branch
     try {
       const remoteShowStdout = (await git(`remote show ${remote}`)).stdout;
       const remoteDefaultBranch = (remoteShowStdout.match(PATTERNS.REMOTE_HEAD_BRANCH) || [])[1];

--- a/src/utils/git.js
+++ b/src/utils/git.js
@@ -13,8 +13,11 @@ const { combine } = require('./structures');
 
 const PATTERNS = {
   ACTIVE_BRANCH: /\*\s+([^\n]+)/,
+  REMOTE_HEAD_BRANCH: /HEAD branch: ([\w-]+)/,
   DETACHED_HEAD: /\(HEAD detached at ([\w]+)\)/
 };
+
+const GIT_DEFAULT_INIT_DEFAULT_BRANCH = 'master';
 
 function git(args = [], options = {}) {
   args = typeof args === 'string' ? args.split(' ') : args;
@@ -36,9 +39,10 @@ module.exports.isRepo = async () => !(await pack(git('rev-parse --git-dir')))[0]
 
 module.exports.isRepoSync = () => !gitSync('rev-parse --git-dir').stderr;
 
-module.exports.getConfigValue = async key => (await git(`config --get ${key}`)).stdout;
+const getConfigValue = (module.exports.getConfigValue = async key => (await git(`config --get ${key}`)).stdout);
 
-module.exports.getRemotes = async () => new Set((await git('remote')).stdout.split('\n').filter(x => x));
+const getRemotes = (module.exports.getRemotes = async () =>
+  new Set((await git('remote')).stdout.split('\n').filter(x => x)));
 
 module.exports.hasChanges = async () => (await git('status -s')).stdout.length > 0;
 
@@ -83,8 +87,33 @@ module.exports.getGithubVersion = async (repo, defaultBranch) => {
   return p.version;
 };
 
-module.exports.getDefaultBranch = async () => {
-  return 'master';
+module.exports.getDefaultBranch = async remote => {
+  const remotes = await getRemotes();
+  let localDefaultBranch;
+
+  if (remotes.has(remote)) {
+    // If we have a valid remote, find out which local branch confured to pull from the remote default branch
+    try {
+      const remoteShowStdout = (await git(`remote show ${remote}`)).stdout;
+      const remoteDefaultBranch = (remoteShowStdout.match(PATTERNS.REMOTE_HEAD_BRANCH) || [])[1];
+      if (remoteDefaultBranch) {
+        localDefaultBranch = (remoteShowStdout.match(
+          new RegExp(`([\\w-]+)\\s+merges with remote ${remoteDefaultBranch}`)
+        ) || [])[1];
+      }
+    } catch (err) {}
+  }
+
+  if (!localDefaultBranch) {
+    // git v2.28 allows you to set `init.defaultBranch` in your global config.
+    // Assume we used this for our local branch (before we set up a remote)
+    try {
+      localDefaultBranch = (await getConfigValue(`--global init.defaultBranch`)).trim();
+    } catch (err) {}
+  }
+
+  // Return a determined local default branch or git's default branch name (master, for now)
+  return localDefaultBranch || GIT_DEFAULT_INIT_DEFAULT_BRANCH;
 };
 
 module.exports.getSemverTags = async () => (await git('tag')).stdout.split('\n').filter(valid).sort(compare);


### PR DESCRIPTION
GitHub now uses `main` as its default branch, and gives you instructions to rename your local default after adding the GitHub repo as a remote. It's not the nicest workflow, but I'm sure it'll improve down the track. It does cause us a wee headache though for newly created aunty projects...

Renaming an aunty project's default branch to `main` causes problems because a few things are hard-coded to assume a git repo's default branch is always called `master`. Previously, you were unable to use `aunty release` (without the `-f` / `--force` flag) if you weren't on the `master` branch. This causes problems when your default branch is called `main` or something else.

This PR stops aunty from assuming that a project repo's default branch is `master` (if possible), allowing existing projects (with a `master` branch) to continue releasing without issue, but supports newly created projects, whether their default branch is `master`, `main`, or anything else we decide to call it down the line.

This would be a simple fix if git was capable of telling you definitively what your current repo's default local branch is, but it cant, so aunty has to make an assumption based on the information available to it. It tries a couple of things, in order:

1. If your repo has a remote set up (e.g. GitHub), we assume its `HEAD` is on the default branch and, following that, assume the local branch which tracks it is the default branch.
2. If you're using `git>=2.28` and have configured[*](#fn1) it to initialise new repos with a default branch name other than `master`, we'll use that.
3. Otherwise, it just assumes git's unmodified default: (`master`)

This is an improvement over the current situation (not being able to release without bypassing _all_ pre-release checks), but you may have noticed that we've traded one problem for another (in a rare edge-case). If you:

- Had configured[*](#fn1) git to initialise new repos with a default branch name other than `master`, then
- Run `aunty release` inside a repo which has a default branch that doesn't match your git config's default **AND** doesn't have a remote set up yet

...it'll refuse to release, no matter what branch you're on. As I said, this should be rare, but if it does crop up, we still have `aunty release --force` as a workaround in a pinch.

### Footnotes

- <span id="footnote" /> You can tell git to initialise repos with a different default branch name by running: `git config --global --set init.defaultBranch <main|whatever>`. If you primarily publish code to GitHub (aunty projects or otherwise), the path of least resistance is to do this ASAP.