### PR TITLE
Make @abcaustralia/postcss-config an optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "node": ">=7.6.0"
   },
   "dependencies": {
-    "@abcaustralia/postcss-config": "^3.5.0",
     "@babel/core": "^7.11.4",
     "@babel/plugin-proposal-class-properties": "^7.5.5",
     "@babel/plugin-proposal-object-rest-spread": "^7.5.5",
@@ -97,6 +96,9 @@
     "write-json-file": "^4.2.0",
     "yeoman-environment": "^2.4.0",
     "yeoman-generator": "^4.0.2"
+  },
+  "optionalDependencies": {
+    "@abcaustralia/postcss-config": "^3.5.0"
   },
   "devDependencies": {
     "eslint": "^7.7.0",

--- a/src/config/webpack.js
+++ b/src/config/webpack.js
@@ -4,7 +4,7 @@ const { join, resolve } = require('path');
 
 // External
 const importLazy = require('import-lazy')(require);
-const getContext = importLazy('@abcaustralia/postcss-config/getContext');
+const getContext = importLazy('@abcaustralia/postcss-config/getContext'); // optional dependency
 const CopyPlugin = importLazy('copy-webpack-plugin');
 const ForkTsCheckerWebpackPlugin = importLazy('fork-ts-checker-webpack-plugin');
 const MiniCssExtractPlugin = importLazy('mini-css-extract-plugin');


### PR DESCRIPTION
`@abcaustralia/*` packages require you to be logged into npm with an ABC-whitelisted user account, which is a problem when you try to auto-build aunty projects on platforms like Vercel.

Making `@abcaustralia/postcss-config` an optional dependency means that `npm install`s will still succeed, even if they have to skip this dependency. Aunty won't miss this dependency as it only tries to lazily import it when the project has `@abcaustralia` dependencies (e.g. Nucleus / ABC components).

This fixes #118