### PR TITLE
Use type aliases instead of interfaces by default

### DIFF
--- a/src/generators/component/templates/preact/component-with-d3.tsx
+++ b/src/generators/component/templates/preact/component-with-d3.tsx
@@ -3,8 +3,8 @@ import { h<% if (isTS) { %>, FunctionalComponent<% } %> } from 'preact';
 import { useEffect, useRef } from 'preact/hooks';
 import styles from './styles.scss';
 <% if (isTS) { %>
-interface <%= className %>Props {
-  color?: string; 
+type <%= className %>Props {
+  color?: string;
 }
 <% } %>
 const <%= className %><% if (isTS) { %>: FunctionalComponent<<%= className %>Props><% } %> = ({ color = 'black' }) => {
@@ -12,7 +12,7 @@ const <%= className %><% if (isTS) { %>: FunctionalComponent<<%= className %>Pro
   const svg = useRef<% if (isTS) { %><Selection<SVGSVGElement, unknown, null, undefined> | null><% } %>(null);
   const g = useRef<% if (isTS) { %><Selection<SVGGElement, unknown, null, undefined> | null><% } %>(null);
   const rect = useRef<% if (isTS) { %><Selection<SVGRectElement, unknown, null, undefined> | null><% } %>(null);
-  
+
   useEffect(() => {
     svg.current = select(root.current)
       .append('svg')

--- a/src/generators/component/templates/preact/component-with-d3.tsx
+++ b/src/generators/component/templates/preact/component-with-d3.tsx
@@ -3,7 +3,7 @@ import { h<% if (isTS) { %>, FunctionalComponent<% } %> } from 'preact';
 import { useEffect, useRef } from 'preact/hooks';
 import styles from './styles.scss';
 <% if (isTS) { %>
-type <%= className %>Props {
+type <%= className %>Props = {
   color?: string;
 }
 <% } %>

--- a/src/generators/component/templates/preact/component.tsx
+++ b/src/generators/component/templates/preact/component.tsx
@@ -1,7 +1,7 @@
 import { h<% if (isTS) { %>, FunctionalComponent<% } %> } from 'preact';
 import styles from './styles.scss';
 <% if (isTS) { %>
-type <%= className %>Props {}
+type <%= className %>Props = {}
 <% } %>
 const <%= className %><% if (isTS) { %>: FunctionalComponent<<%= className %>Props><% } %> = () => {
   return (

--- a/src/generators/component/templates/preact/component.tsx
+++ b/src/generators/component/templates/preact/component.tsx
@@ -1,7 +1,7 @@
 import { h<% if (isTS) { %>, FunctionalComponent<% } %> } from 'preact';
 import styles from './styles.scss';
 <% if (isTS) { %>
-interface <%= className %>Props {}
+type <%= className %>Props {}
 <% } %>
 const <%= className %><% if (isTS) { %>: FunctionalComponent<<%= className %>Props><% } %> = () => {
   return (

--- a/src/generators/component/templates/react/component-with-d3.tsx
+++ b/src/generators/component/templates/react/component-with-d3.tsx
@@ -2,7 +2,7 @@ import { select<% if (isTS) { %>, Selection<% } %> } from 'd3-selection';
 import React, { useEffect, useRef } from 'react';
 import styles from './styles.scss';
 <% if (isTS) { %>
-type <%= className %>Props {
+type <%= className %>Props = {
   color?: string;
 }
 <% } %>

--- a/src/generators/component/templates/react/component-with-d3.tsx
+++ b/src/generators/component/templates/react/component-with-d3.tsx
@@ -2,8 +2,8 @@ import { select<% if (isTS) { %>, Selection<% } %> } from 'd3-selection';
 import React, { useEffect, useRef } from 'react';
 import styles from './styles.scss';
 <% if (isTS) { %>
-interface <%= className %>Props {
-  color?: string; 
+type <%= className %>Props {
+  color?: string;
 }
 <% } %>
 const <%= className %><% if (isTS) { %>: React.FC<<%= className %>Props><% } %> = ({ color = 'black' }) => {
@@ -11,7 +11,7 @@ const <%= className %><% if (isTS) { %>: React.FC<<%= className %>Props><% } %> 
   const svg = useRef<% if (isTS) { %><Selection<SVGSVGElement, unknown, null, undefined> | null><% } %>(null);
   const g = useRef<% if (isTS) { %><Selection<SVGGElement, unknown, null, undefined> | null><% } %>(null);
   const rect = useRef<% if (isTS) { %><Selection<SVGRectElement, unknown, null, undefined> | null><% } %>(null);
-  
+
   useEffect(() => {
     svg.current = select(root.current)
       .append('svg')

--- a/src/generators/component/templates/react/component.tsx
+++ b/src/generators/component/templates/react/component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styles from './styles.scss';
 <% if (isTS) { %>
-type <%= className %>Props {}
+type <%= className %>Props = {}
 <% } %>
 const <%= className %><% if (isTS) { %>: React.FC<<%= className %>Props><% } %> = () => {
   return (

--- a/src/generators/component/templates/react/component.tsx
+++ b/src/generators/component/templates/react/component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styles from './styles.scss';
 <% if (isTS) { %>
-interface <%= className %>Props {}
+type <%= className %>Props {}
 <% } %>
 const <%= className %><% if (isTS) { %>: React.FC<<%= className %>Props><% } %> = () => {
   return (

--- a/src/generators/component/templates/vue/component-with-d3.vue
+++ b/src/generators/component/templates/vue/component-with-d3.vue
@@ -6,7 +6,7 @@
 import Vue from 'vue';
 import { select<% if (isTS) { %>, Selection<% } %> } from 'd3-selection';
 <% if (isTS) { %>
-type <%= className %>Data {
+type <%= className %>Data = {
   svg: Selection<SVGSVGElement, unknown, null, undefined> | null;
   g: Selection<SVGGElement, unknown, null, undefined> | null;
   rect: Selection<SVGRectElement, unknown, null, undefined> | null;

--- a/src/generators/component/templates/vue/component-with-d3.vue
+++ b/src/generators/component/templates/vue/component-with-d3.vue
@@ -6,7 +6,7 @@
 import Vue from 'vue';
 import { select<% if (isTS) { %>, Selection<% } %> } from 'd3-selection';
 <% if (isTS) { %>
-interface <%= className %>Data {
+type <%= className %>Data {
   svg: Selection<SVGSVGElement, unknown, null, undefined> | null;
   g: Selection<SVGGElement, unknown, null, undefined> | null;
   rect: Selection<SVGRectElement, unknown, null, undefined> | null;

--- a/src/generators/project/templates/basic/src/components/App/index.ts
+++ b/src/generators/project/templates/basic/src/components/App/index.ts
@@ -1,7 +1,7 @@
 import Worm from '../Worm';
 import styles from './styles.scss';
 <% if (isTS) { %>
-export interface AppProps {
+export type AppProps {
   x: number;
   y: string;
   z: boolean;

--- a/src/generators/project/templates/basic/src/components/App/index.ts
+++ b/src/generators/project/templates/basic/src/components/App/index.ts
@@ -1,7 +1,7 @@
 import Worm from '../Worm';
 import styles from './styles.scss';
 <% if (isTS) { %>
-export type AppProps {
+export type AppProps = {
   x: number;
   y: string;
   z: boolean;

--- a/src/generators/project/templates/basic/src/components/ErrorBox/index.ts
+++ b/src/generators/project/templates/basic/src/components/ErrorBox/index.ts
@@ -1,6 +1,6 @@
 import styles from './styles.scss';
 <% if (isTS) { %>
-type ErrorBoxProps {
+type ErrorBoxProps = {
   error: Error;
 }
 <% } %>

--- a/src/generators/project/templates/basic/src/components/ErrorBox/index.ts
+++ b/src/generators/project/templates/basic/src/components/ErrorBox/index.ts
@@ -1,6 +1,6 @@
 import styles from './styles.scss';
 <% if (isTS) { %>
-interface ErrorBoxProps {
+type ErrorBoxProps {
   error: Error;
 }
 <% } %>

--- a/src/generators/project/templates/preact/src/components/App/index.tsx
+++ b/src/generators/project/templates/preact/src/components/App/index.tsx
@@ -2,7 +2,7 @@ import { h<% if (isTS) { %>, FunctionalComponent<% } %> } from 'preact';
 import Worm from '../Worm';
 import styles from './styles.scss';
 <% if (isTS) { %>
-export type AppProps {
+export type AppProps = {
   x: number;
   y: string;
   z: boolean;

--- a/src/generators/project/templates/preact/src/components/App/index.tsx
+++ b/src/generators/project/templates/preact/src/components/App/index.tsx
@@ -2,7 +2,7 @@ import { h<% if (isTS) { %>, FunctionalComponent<% } %> } from 'preact';
 import Worm from '../Worm';
 import styles from './styles.scss';
 <% if (isTS) { %>
-export interface AppProps {
+export type AppProps {
   x: number;
   y: string;
   z: boolean;

--- a/src/generators/project/templates/preact/src/components/ErrorBox/index.tsx
+++ b/src/generators/project/templates/preact/src/components/ErrorBox/index.tsx
@@ -2,7 +2,7 @@ import { h<% if (isTS) { %>, FunctionalComponent<% } %> } from 'preact';
 import { useEffect } from 'preact/hooks';
 import styles from './styles.scss';
 <% if (isTS) { %>
-type ErrorBoxProps {
+type ErrorBoxProps = {
   error: Error;
 }
 <% } %>

--- a/src/generators/project/templates/preact/src/components/ErrorBox/index.tsx
+++ b/src/generators/project/templates/preact/src/components/ErrorBox/index.tsx
@@ -2,7 +2,7 @@ import { h<% if (isTS) { %>, FunctionalComponent<% } %> } from 'preact';
 import { useEffect } from 'preact/hooks';
 import styles from './styles.scss';
 <% if (isTS) { %>
-interface ErrorBoxProps {
+type ErrorBoxProps {
   error: Error;
 }
 <% } %>

--- a/src/generators/project/templates/react/src/components/App/index.tsx
+++ b/src/generators/project/templates/react/src/components/App/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Worm from '../Worm';
 import styles from './styles.scss';
 <% if (isTS) { %>
-export type AppProps {
+export type AppProps = {
   x: number;
   y: string;
   z: boolean;

--- a/src/generators/project/templates/react/src/components/App/index.tsx
+++ b/src/generators/project/templates/react/src/components/App/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Worm from '../Worm';
 import styles from './styles.scss';
 <% if (isTS) { %>
-export interface AppProps {
+export type AppProps {
   x: number;
   y: string;
   z: boolean;

--- a/src/generators/project/templates/react/src/components/ErrorBox/index.tsx
+++ b/src/generators/project/templates/react/src/components/ErrorBox/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import styles from './styles.scss';
 <% if (isTS) { %>
-type ErrorBoxProps {
+type ErrorBoxProps = {
   error: Error;
 }
 <% } %>

--- a/src/generators/project/templates/react/src/components/ErrorBox/index.tsx
+++ b/src/generators/project/templates/react/src/components/ErrorBox/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import styles from './styles.scss';
 <% if (isTS) { %>
-interface ErrorBoxProps {
+type ErrorBoxProps {
   error: Error;
 }
 <% } %>


### PR DESCRIPTION
There's [conflicting recommendations](https://blog.logrocket.com/types-vs-interfaces-in-typescript/) on whether component props should be typed with an alias or an interface, but the only good reason I can think of for using an interface declaration is in a class context. Since our component templates universally use functional components (and for all the reasons [described here](https://dev.to/reyronald/typescript-types-or-interfaces-for-react-component-props-1408)) I think it makes more sense to use type aliases.

﻿