### PR TITLE
Multiple entry point support

### DIFF
--- a/src/config/webpack.js
+++ b/src/config/webpack.js
@@ -115,6 +115,12 @@ module.exports.getWebpackConfig = () => {
   return config;
 };
 
+const createEntriesDictionary = (root, from, entry) =>
+  (Array.isArray(entry) ? entry : [entry]).reduce(
+    (memo, _entry) => ({ ...memo, [_entry]: [join(root, from, _entry)] }),
+    {}
+  );
+
 function createWebpackConfig({ isModernJS } = {}) {
   const { pkg, root, hasTS, type, webpack: projectWebpackConfig } = getProjectConfig();
   const { entry, extractCSS, from, staticDir, to, useCSSModules } = getBuildConfig();
@@ -124,9 +130,7 @@ function createWebpackConfig({ isModernJS } = {}) {
     {
       mode: isProd ? 'production' : 'development',
       cache: true,
-      entry: {
-        index: [join(root, from, entry)]
-      },
+      entry: createEntriesDictionary(root, from, entry),
       devtool: 'source-map',
       output: {
         path: join(root, to),


### PR DESCRIPTION
This extends the `build::entry` config prop (previously used to change the expected entry filename from the default `index`) to also accept an array of strings. Each will be considered an entry point.

Now, renaming the default entry point (by setting `build::entry` to a different string, or a unit array, will ensure the output filename matches that entry filename, rather than it being renamed to `index.js`.

If you want to keep the default `index` around, just include it as one of your array items.

Closes #131 (see for reference implementation, and the existing hacks we plan to avoid).