### PR TITLE
Support a configurable list of dependencies we want babel to transpile when we build

### DIFF
--- a/src/config/build.js
+++ b/src/config/build.js
@@ -25,6 +25,7 @@ module.exports.getBuildConfig = mem(() => {
       to: BUILD_DIRECTORY_NAME,
       staticDir: DEFAULT_STATIC_DIRECTORY_NAME,
       addModernJS: false,
+      includedDependencies: [],
       extractCSS: false,
       useCSSModules: true,
       showDeprecations: false

--- a/src/config/webpack.js
+++ b/src/config/webpack.js
@@ -115,9 +115,27 @@ module.exports.getWebpackConfig = () => {
   return config;
 };
 
+const resolveIncludedDependencies = (includedDependencies, root) => {
+  if (!Array.isArray(includedDependencies)) {
+    return [];
+  }
+
+  return includedDependencies.map(packageNameOrPattern => {
+    if (typeof packageNameOrPattern === 'string') {
+      return resolve(root, 'node_modules', packageNameOrPattern);
+    }
+
+    if (packageNameOrPattern instanceof RegExp) {
+      return new RegExp(join('node_modules', packageNameOrPattern.source), packageNameOrPattern.flags);
+    }
+
+    return null;
+  });
+};
+
 function createWebpackConfig({ isModernJS } = {}) {
   const { pkg, root, hasTS, type, webpack: projectWebpackConfig } = getProjectConfig();
-  const { entry, extractCSS, from, staticDir, to, useCSSModules } = getBuildConfig();
+  const { entry, extractCSS, from, includedDependencies, staticDir, to, useCSSModules } = getBuildConfig();
   const isProd = process.env.NODE_ENV === 'production';
 
   const config = merge(
@@ -147,7 +165,7 @@ function createWebpackConfig({ isModernJS } = {}) {
           {
             __hint__: 'scripts',
             test: hasTS ? /\.m?[jt]sx?$/ : /\.m?jsx?$/,
-            include: [resolve(root, from)],
+            include: [resolve(root, from)].concat(resolveIncludedDependencies(includedDependencies, root)),
             loader: require.resolve('babel-loader'),
             options: getBabelConfig({ isModernJS })
           },


### PR DESCRIPTION
This adds an `includedDependencies` prop to the build config which can be used to list packages in node_modules (as strings or regexes) that we want babel to transpile.

Closes #132 (see for reference implementation, and the existing hacks we plan to avoid).