### PR TITLE
New .aunty output directory (replacing .build dir and .deploy file)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
     "Joshua Byrd <byrd.joshua@abc.net.au>"
   ],
   "scripts": {
+    "postinstall": "node scripts/postinstall.js",
     "release": "release-it"
   },
   "files": [
     "assets",
+    "scripts",
     "src",
     "ts"
   ],

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,44 @@
+/*
+    Aunty v13 changes how build artefacts are created. When building a project,
+    pre-v13, a .build folder and .deploy files were created inside your project
+    directory. In v13, this was changed to a single .aunty directory, which
+    contains a build filder and deploy.json file.
+
+    This script runs after aunty is installed inside a project directory, and
+    if the project was upgraded from a pre-v13 aunty, it will delete any old
+    build artefacts, and update the .gitignore file to make sure the .aunty
+    directory isn't committed, and remove the .build & .deploy references.
+*/
+
+const { existsSync, readFileSync, rmSync, rmdirSync, writeFileSync } = require('fs');
+const { join } = require('path');
+
+const INSTALLATION_DIRECTORY = process.env.INIT_CWD || '.';
+
+const PRE_AUNTY_13_GITIGNORE_PATTERN = /\/\.build\n\/\.deploy/;
+const POST_AUNTY_13_GITIGNORE_REPLACEMENT = `/.aunty`;
+
+const PRE_AUNTY_13_BUILD_DIR_PATH = join(INSTALLATION_DIRECTORY, '.build');
+const PRE_AUNTY_13_DEPLOY_CONFIG_FILE_PATH = join(INSTALLATION_DIRECTORY, '.deploy');
+const GITIGNORE_PATH = join(INSTALLATION_DIRECTORY, '.gitignore');
+
+if (existsSync(PRE_AUNTY_13_BUILD_DIR_PATH)) {
+  rmdirSync(PRE_AUNTY_13_BUILD_DIR_PATH, { recursive: true });
+}
+
+if (existsSync(PRE_AUNTY_13_DEPLOY_CONFIG_FILE_PATH)) {
+  rmSync(PRE_AUNTY_13_DEPLOY_CONFIG_FILE_PATH);
+}
+
+if (existsSync(GITIGNORE_PATH)) {
+  const fileContents = readFileSync(GITIGNORE_PATH, 'utf8');
+
+  if (PRE_AUNTY_13_GITIGNORE_PATTERN.test(fileContents)) {
+    const updatedFileContents = fileContents.replace(
+      PRE_AUNTY_13_GITIGNORE_PATTERN,
+      POST_AUNTY_13_GITIGNORE_REPLACEMENT
+    );
+
+    writeFileSync(GITIGNORE_PATH, updatedFileContents);
+  }
+}

--- a/src/cli/build/index.js
+++ b/src/cli/build/index.js
@@ -11,7 +11,7 @@ const writeJsonFile = importLazy('write-json-file');
 const { getDeployConfig } = require('../../config/deploy');
 const { getProjectConfig } = require('../../config/project');
 const { getWebpackConfig } = require('../../config/webpack');
-const { DEPLOY_FILE_NAME } = require('../../constants');
+const { DEPLOY_FILE_NAME, OUTPUT_DIRECTORY_NAME } = require('../../constants');
 const { packs, throws, unpack } = require('../../utils/async');
 const { dry, info, spin, warn } = require('../../utils/logging');
 const { combine } = require('../../utils/structures');
@@ -71,7 +71,7 @@ module.exports = command(
       const errors = stats.toJson({}, true).errors;
 
       spinner.fail();
-      
+
       if (errors.length > 1) {
         throw MESSAGES.multipleErrors(errors.map(error => error.message));
       }
@@ -88,7 +88,7 @@ module.exports = command(
 
     if (deployConfig) {
       spinner = spin('Creating deploy configuration');
-      writeJsonFile.sync(join(root, DEPLOY_FILE_NAME), deployConfig);
+      writeJsonFile.sync(join(root, OUTPUT_DIRECTORY_NAME, DEPLOY_FILE_NAME), deployConfig);
       spinner.succeed('Created deploy configuration');
     }
   }

--- a/src/cli/clean/index.js
+++ b/src/cli/clean/index.js
@@ -3,9 +3,8 @@ const importLazy = require('import-lazy')(require);
 const del = importLazy('del');
 
 // Ours
-const { getBuildConfig } = require('../../config/build');
 const { getProjectConfig } = require('../../config/project');
-const { DEPLOY_FILE_NAME } = require('../../constants');
+const { OUTPUT_DIRECTORY_NAME } = require('../../constants');
 const { hvy } = require('../../utils/color');
 const { dry, info, spin } = require('../../utils/logging');
 const { inlineList } = require('../../utils/text');
@@ -19,8 +18,7 @@ module.exports = command(
   },
   async argv => {
     const { root } = getProjectConfig();
-    const { to } = getBuildConfig();
-    const globs = [to, DEPLOY_FILE_NAME];
+    const globs = [OUTPUT_DIRECTORY_NAME];
 
     if (argv.dry) {
       return dry({

--- a/src/cli/deploy/index.js
+++ b/src/cli/deploy/index.js
@@ -10,7 +10,7 @@ const loadJsonFile = importLazy('load-json-file');
 const { command } = require('../');
 const { addProfileProperties } = require('../../config/deploy');
 const { getProjectConfig } = require('../../config/project');
-const { DEPLOY_FILE_NAME } = require('../../constants');
+const { DEPLOY_FILE_NAME, OUTPUT_DIRECTORY_NAME } = require('../../constants');
 const { packs, throws, unpack } = require('../../utils/async');
 const { dry, info, spin, warn } = require('../../utils/logging');
 const { ftp, rsync } = require('../../utils/remote');
@@ -29,7 +29,7 @@ module.exports = command(
     // 1) Load the deploy configuration (created by the build process)
 
     try {
-      deployConfig = loadJsonFile.sync(join(root, DEPLOY_FILE_NAME));
+      deployConfig = loadJsonFile.sync(join(root, OUTPUT_DIRECTORY_NAME, DEPLOY_FILE_NAME));
     } catch (err) {
       throw new Error(MESSAGES.noDeployConfigFile);
     }

--- a/src/config/build.js
+++ b/src/config/build.js
@@ -1,8 +1,11 @@
+// Native
+const { join } = require('path');
+
 // External
 const mem = require('mem');
 
 // Ours
-const { BUILD_DIRECTORY_NAME } = require('../constants');
+const { BUILD_DIRECTORY_NAME, OUTPUT_DIRECTORY_NAME } = require('../constants');
 const { combine } = require('../utils/structures');
 const { getProjectConfig } = require('./project');
 
@@ -22,7 +25,7 @@ module.exports.getBuildConfig = mem(() => {
     {
       entry: DEFAULT_ENTRY_FILE_NAME,
       from: DEFAULT_SOURCE_DIRECTORY_NAME,
-      to: BUILD_DIRECTORY_NAME,
+      to: join(OUTPUT_DIRECTORY_NAME, BUILD_DIRECTORY_NAME),
       staticDir: DEFAULT_STATIC_DIRECTORY_NAME,
       addModernJS: false,
       includedDependencies: [],

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,6 @@
 module.exports = {
-  BUILD_DIRECTORY_NAME: '.build',
-  DEPLOY_FILE_NAME: '.deploy',
+  OUTPUT_DIRECTORY_NAME: '.aunty',
+  BUILD_DIRECTORY_NAME: 'build',
+  DEPLOY_FILE_NAME: 'deploy.json',
   PROJECT_CONFIG_FILE_NAME: 'aunty.config.js'
 };

--- a/src/generators/project/index.js
+++ b/src/generators/project/index.js
@@ -8,7 +8,7 @@ const requireg = require('requireg');
 const Generator = require('yeoman-generator');
 
 // Ours
-const { BUILD_DIRECTORY_NAME, DEPLOY_FILE_NAME } = require('../../constants');
+const { OUTPUT_DIRECTORY_NAME } = require('../../constants');
 const { cmd, hvy, opt, sec } = require('../../utils/color');
 const { success } = require('../../utils/logging');
 const { installDependencies } = require('../../utils/npm');
@@ -114,8 +114,7 @@ Shorthand examples (assuming xyz is your project name):
 
   writing() {
     const context = {
-      BUILD_DIRECTORY_NAME,
-      DEPLOY_FILE_NAME,
+      OUTPUT_DIRECTORY_NAME,
       projectName: this.options.projectName,
       projectNameSlug: this.options.projectNameSlug,
       projectNameFlat: this.options.projectNameFlat,

--- a/src/generators/project/templates/_common/_.gitignore
+++ b/src/generators/project/templates/_common/_.gitignore
@@ -2,8 +2,7 @@
 /node_modules
 
 # output
-/<%= BUILD_DIRECTORY_NAME %>
-/<%= DEPLOY_FILE_NAME %>
+/<%= OUTPUT_DIRECTORY_NAME %>
 
 # misc
 .DS_Store


### PR DESCRIPTION
- Move built projects and deploy configurations into a `.aunty` directory, rather than creating two artefacts in the project directory.
- Rename build directory from `.build` to `build` so it's not hidden from file explorers by default
- Rename deploy configuration file from `.deploy` to `deploy.json` so that it gets syntax highlighting in editors.
- Update `clean` command to remove the `.aunty` directory
- Create an npm `postinstall` script which updates `.gitignore` files and clears old artefacts when aunty is upgraded in an existing project
- Update output artefact references in `.gitignore` file in project generator template