### PR TITLE
Add `dotenv` support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "csv-loader": "^3.0.3",
         "deepmerge": "^4.0.0",
         "del": "^6.0.0",
+        "dotenv": "^16.0.3",
         "dotenv-webpack": "^8.0.1",
         "execa": "^5.0.0",
         "fork-ts-checker-webpack-plugin": "^6.2.1",
@@ -5907,11 +5908,11 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/dotenv-defaults": {
@@ -5920,6 +5921,14 @@
       "integrity": "sha512-iOIzovWfsUHU91L5i8bJce3NYK5JXeAwH50Jh6+ARUdLiiGlYWfGw6UkzsYqaXZH/hjE/eCd/PlfM/qqyK0AMg==",
       "dependencies": {
         "dotenv": "^8.2.0"
+      }
+    },
+    "node_modules/dotenv-defaults/node_modules/dotenv": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/dotenv-webpack": {
@@ -22824,9 +22833,9 @@
       }
     },
     "dotenv": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
     },
     "dotenv-defaults": {
       "version": "2.0.2",
@@ -22834,6 +22843,13 @@
       "integrity": "sha512-iOIzovWfsUHU91L5i8bJce3NYK5JXeAwH50Jh6+ARUdLiiGlYWfGw6UkzsYqaXZH/hjE/eCd/PlfM/qqyK0AMg==",
       "requires": {
         "dotenv": "^8.2.0"
+      },
+      "dependencies": {
+        "dotenv": {
+          "version": "8.6.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+          "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="
+        }
       }
     },
     "dotenv-webpack": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "csv-loader": "^3.0.3",
         "deepmerge": "^4.0.0",
         "del": "^6.0.0",
+        "dotenv-webpack": "^8.0.1",
         "execa": "^5.0.0",
         "fork-ts-checker-webpack-plugin": "^6.2.1",
         "ftp-deploy": "^2.3.8",
@@ -5903,6 +5904,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/dotenv-defaults": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-2.0.2.tgz",
+      "integrity": "sha512-iOIzovWfsUHU91L5i8bJce3NYK5JXeAwH50Jh6+ARUdLiiGlYWfGw6UkzsYqaXZH/hjE/eCd/PlfM/qqyK0AMg==",
+      "dependencies": {
+        "dotenv": "^8.2.0"
+      }
+    },
+    "node_modules/dotenv-webpack": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-8.0.1.tgz",
+      "integrity": "sha512-CdrgfhZOnx4uB18SgaoP9XHRN2v48BbjuXQsZY5ixs5A8579NxQkmMxRtI7aTwSiSQcM2ao12Fdu+L3ZS3bG4w==",
+      "dependencies": {
+        "dotenv-defaults": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "webpack": "^4 || ^5"
       }
     },
     "node_modules/duplexer": {
@@ -22790,6 +22821,27 @@
       "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
       "requires": {
         "is-obj": "^2.0.0"
+      }
+    },
+    "dotenv": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="
+    },
+    "dotenv-defaults": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-2.0.2.tgz",
+      "integrity": "sha512-iOIzovWfsUHU91L5i8bJce3NYK5JXeAwH50Jh6+ARUdLiiGlYWfGw6UkzsYqaXZH/hjE/eCd/PlfM/qqyK0AMg==",
+      "requires": {
+        "dotenv": "^8.2.0"
+      }
+    },
+    "dotenv-webpack": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-8.0.1.tgz",
+      "integrity": "sha512-CdrgfhZOnx4uB18SgaoP9XHRN2v48BbjuXQsZY5ixs5A8579NxQkmMxRtI7aTwSiSQcM2ao12Fdu+L3ZS3bG4w==",
+      "requires": {
+        "dotenv-defaults": "^2.0.2"
       }
     },
     "duplexer": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "csv-loader": "^3.0.3",
     "deepmerge": "^4.0.0",
     "del": "^6.0.0",
+    "dotenv": "^16.0.3",
     "dotenv-webpack": "^8.0.1",
     "execa": "^5.0.0",
     "fork-ts-checker-webpack-plugin": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "csv-loader": "^3.0.3",
     "deepmerge": "^4.0.0",
     "del": "^6.0.0",
+    "dotenv-webpack": "^8.0.1",
     "execa": "^5.0.0",
     "fork-ts-checker-webpack-plugin": "^6.2.1",
     "ftp-deploy": "^2.3.8",

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1,3 +1,6 @@
+// Env
+require('dotenv').config();
+
 // Native
 const { resolve } = require('path');
 

--- a/src/config/webpack.js
+++ b/src/config/webpack.js
@@ -6,6 +6,7 @@ const { join, resolve } = require('path');
 const importLazy = require('import-lazy')(require);
 const getContext = importLazy('@abcaustralia/postcss-config/getContext'); // optional dependency
 const CopyPlugin = importLazy('copy-webpack-plugin');
+const Dotenv = importLazy('dotenv-webpack');
 const ForkTsCheckerWebpackPlugin = importLazy('fork-ts-checker-webpack-plugin');
 const MiniCssExtractPlugin = importLazy('mini-css-extract-plugin');
 const sveltePreprocess = importLazy('svelte-preprocess');
@@ -231,6 +232,7 @@ function createWebpackConfig({ isModernJS } = {}) {
       },
       plugins: [
         new EnvironmentPlugin(Object.keys(process.env)),
+        new Dotenv(),
         hasTS
           ? new ForkTsCheckerWebpackPlugin({
               logger: { infrastructure: 'silent', issues: 'silent' },

--- a/src/generators/project/templates/_common/_.gitignore
+++ b/src/generators/project/templates/_common/_.gitignore
@@ -1,6 +1,9 @@
 # dependencies
 /node_modules
 
+# environment
+.env
+
 # output
 /<%= OUTPUT_DIRECTORY_NAME %>
 


### PR DESCRIPTION
This will effectively allow you to replace instances of `process.env.*` with variables defined in a project's `.env` file at build time. This replacement also applies to imported packages.

Aunty has always replaced known environment variables, but until now you couldn't define them in a `.env` file. This is a capability that Vite already has (but it chooses to only repalce `VITE_`-prefixed variables).

This is the plugin: [dotenv-webpack]()https://www.npmjs.com/package/dotenv-webpack. It's the one recommended in the Webpack 5 docs for this purpose. I've used it without overriding any default settings, and it seems to fit our needs well.

I've also added `.env` to the project templates' shared `.gitignore` file, just to make adoption a wee bit smoother.
