### PR TITLE
Multiple static directory support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,20 @@ Overrides should be used sparingly, as the advantages of using a single-dependen
 
 If you don't need to override any of the project defaults, your entire aunty configuration can be a string containing the project type, as a shorthand for `{type: "<project_type>"}`. `type` is the only required property in your aunty configuration.
 
+#### `build` config properties
+
+| property               | default          | description                                                                                                                                                                     |
+| ---------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `entry`                | `"index"`        | The entry file for your project (extension should be unspecified). You can optionally supply an array for multiple entry points, which will result in multiple outputs.         |
+| `from`                 | `"src"`          | The source directory that aunty will look for your entry file(s) in.                                                                                                            |
+| `to`                   | `".aunty/build"` | The destination directory for your compiled and static assets.                                                                                                                  |
+| `staticDir`            | `"public"`       | The directory you store static assets in. You can optionally supply an array of directories, which will be merged at build time.                                                |
+| `addModernJS`          | `false`          | Setting this to true will enable a 2nd output file for each entry file named `{name}.modern.js`, which is skips browserlist-based feature polyfilling                           |
+| `includedDependencies` | `[]`             | Any packages (defined by name string or name-matching `RegExp`s) you add to this array will be transpiled in the same manner as the project source.                             |
+| `extractCSS`           | `false`          | Setting this to true will create a separate `{name}.css` output for each input, rather than bundling it with the JS (for dynamic `<style>` insertion).                          |
+| `useCSSModules`        | `true`           | Setting this to false will turn off CSS module compilation. All styles written will be 'global', and importing CSS files will not give you an object of `className` references. |
+| `showDeprecations`     | `false`          | Setting this to true will allow NodeJS to output stack traces of deprecation warnings.                                                                                          |
+
 ### Generators
 
 Aunty comes with a few basic generators. Run `aunty generate --help` for the full list, or `aunty generate <generator> --help` for further details.
@@ -114,40 +128,6 @@ import 'regenerator-runtime/runtime';
 ```
 
 Note: You may also need a `Promise` polyfill for IE11.
-
-### Multiple entry points
-
-By default Aunty looks for `index.js` in `src/`. Enable multiple entry points by adding a `build::entry` config to `aunty.config.js`.
-
-#### Replace 'index' with 'story'
-
-```js
-module.exports = {
-  build: {
-    entry: 'story' // will now also support `['story']`
-  }
-};
-```
-
-#### Replace 'index' with 'story', 'editor', 'graphic' & 'polyfills'
-
-```js
-module.exports = {
-  build: {
-    entry: ['story', 'editor', 'graphic', 'polyfills']
-  }
-};
-```
-
-#### Retain 'index'; add 'editor', 'graphic' & 'polyfills'
-
-```js
-module.exports = {
-  build: {
-    entry: ['index', 'editor', 'graphic', 'polyfills']
-  }
-};
-```
 
 ## Authors
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ module.exports = {
   // aunty command configuration
   build: {…},
   serve: {…},
-  deploy: {…},
+  deploy: [{…}],
   // internal tools configuration
   babel: {…},
   jest: {…},
@@ -75,7 +75,7 @@ module.exports = {
   "type": "<project_type>",
   "build": {…},
   "serve": {…},
-  "deploy": {…},
+  "deploy": [{…}],
   "babel": {…},
   "jest": {…},
   "webpack": {…},
@@ -85,7 +85,7 @@ module.exports = {
 
 Supported project `type`s (currently: `basic`, `preact`, `react` & `svelte`) have their own default build configuration, but you can override it by extending your project configuration.
 
-The `build`, `serve` and `deploy` properties allow you to override the default settings for those respective commands.
+The `build`, `serve` and `deploy` properties allow you to override the default settings for those respective commands. Their respective properties (and default values) are documented below.
 
 Aunty uses some tools internally, which you can also provide custom configuration for. If you supply an object for the `babel`, `jest`, `webpack`, and/or `webpackDevServer` properties, that object will be merged into the default configuration. Optionally, you can supply a function (for any property), which will be passed the default configuration for you to manually modify and return.
 
@@ -112,6 +112,31 @@ If you don't need to override any of the project defaults, your entire aunty con
 | `extractCSS`           | `false`          | Setting this to true will create a separate `{name}.css` output for each input, rather than bundling it with the JS (for dynamic `<style>` insertion).                          |
 | `useCSSModules`        | `true`           | Setting this to false will turn off CSS module compilation. All styles written will be 'global', and importing CSS files will not give you an object of `className` references. |
 | `showDeprecations`     | `false`          | Setting this to true will allow NodeJS to output stack traces of deprecation warnings.                                                                                          |
+
+#### `serve` config properties
+
+| property            | default       | description                                                                                                                                                                                                                                    |
+| ------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `hasBundleAnalysis` | `false`       | Setting this to true will spin up a second server on another port, allowing you to inspect your bundle. The address will be logged to the console when the dev server starts.                                                                  |
+| `host`              | `"localhost"` | The hostname of your dev server. If you're on the ABC internal network, the default will change to your machine's hostname (`ws<number>.aus.aunty.abc.net.au`). The `AUNTY_HOST` environment variable, if present, will override this setting. |
+| `hot`               | `true`        | Should the dev server enable hot reloading. If `NODE_ENV !== "development"`, the default will change to `false`.                                                                                                                               |
+| `https`             | `true`        | Should the dev server use SSL (with a self-signed certificate matching the `host`). You can alternatively supply your own `{cert: string, key: string` object if you've generated your certificate some other way.                             |
+| `port`              | `8000`        | The port number of your dev server. If the port specified is unavailable, **aunty** will try incrementing the port number until it finds an available one. The `AUNTY_PORT` environment variable, if present, will override this setting.      |
+
+#### `deploy` config properties
+
+`deploy` should be an array of config objects, one for each deployment target (e.g. ContentFTP)
+
+| property            | default                 | description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| ------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `from`              | build config `to` value | The directory to deploy files from (if you haven't overridden the build `to` value, it should be ".aunty/build")                                                                                                                                                                                                                                                                                                                                                                                        |
+| `files`             | `"**"`                  | A glob matching the files under your `from` directory to deploy                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `profile`           | `"contentftp"`          | This should be the name of a key in your `~/.abc-credentials` file, which will be consulted to populate login credentials. If this is `"contentftp"` it will also populate the config's `to` and `resolvePublicPath` properties.                                                                                                                                                                                                                                                                        |
+| `publicPath`        | `"/"`                   | If `resolvePublicPath` is defined, `publicPath` will be overwritten by the return value of that function.                                                                                                                                                                                                                                                                                                                                                                                               |
+| `resolvePublicPath` | `undefined`             | A function which takes the initial config as an object, and returns an updated `publicPath`. If `profile="contentftp"`, this will be a function that knows how ContentFTP directories map onto ABC URLs.                                                                                                                                                                                                                                                                                                |
+| `to`                | `undefined`             | The directory on your target to deploy files to. If `profile="contentftp"` , this will be a versioned directory where we deploy News projects to. If you set this to a string, the patterns `<name>` and `<id>` will be replaced by the project name, and the current deployment ID, respectively. During releases, `id` is the current version; during development, it's the current git branch name. You can also specify a custom deployment ID by using the `--id` flag when running `aunty build`. |
+
+You _could_ also specify `type` (`"ftp"`/`"ssh"`), `host`, `port`, `username` & `password`, but these are best left inside your `.abc-credentials` file.
 
 ### Generators
 

--- a/src/config/webpack.js
+++ b/src/config/webpack.js
@@ -248,11 +248,9 @@ function createWebpackConfig({ isModernJS } = {}) {
             })
           : null,
         new CopyPlugin({
-          patterns: [
-            {
-              from: join(root, staticDir)
-            }
-          ]
+          patterns: (Array.isArray(staticDir) ? staticDir : [staticDir]).map(dirName => ({
+            from: join(root, dirName)
+          }))
         })
       ].filter(x => x),
       optimization: {

--- a/src/config/webpackDevServer.js
+++ b/src/config/webpackDevServer.js
@@ -36,9 +36,9 @@ module.exports.getWebpackDevServerConfig = async () => {
             }
           : 'https'
         : 'http',
-      static: {
-        directory: join(root, staticDir)
-      }
+      static: (Array.isArray(staticDir) ? staticDir : [staticDir]).map(dirName => ({
+        directory: join(root, dirName)
+      }))
     },
     projectWebpackDevServerConfig
   );


### PR DESCRIPTION
This allows the definition of multiple static directories, by setting your aunty config's `build->staticDir` property to an array of strings.

@thomasbrettell asked for a way to use some static assets while developing locally, but exclude them from versioned production releases. This is also a problem I've tried to hack around in the past (during projects like the Aus Talks data explorer and our COVID charts).

## Example usage

A common pattern this would be great for would be serving a local directory of data files during development, but pushing those files to a location under `/dat/` on ContentFTP (before publication), and forking which endpoint to reference using the `NODE_ENV` environment variable.

Assuming you had this file in your project: `/data/big-chunk-o-data.csv`...

#### In `aunty.config.js`:

```
module.exports = {
  build: {
    staticDir: process.env.NODE_ENV === 'development' ? ['public', 'data'] : 'public'
  }
};
```

#### In `src/index.js`:

```
const ENDPOINT = process.env.NODE_ENV === 'development' ?
  __webpack_public_path__ :
  "https://www.abc.net.au/dat/news/interactives/project-name/"

fetch(`${ENDPOINT}big-chunk-o-data.csv`).then(...)
```

