### PR TITLE
Stop TypeScript compilation error for new projects

### DIFF
--- a/src/generators/project/templates/react/src/index.tsx
+++ b/src/generators/project/templates/react/src/index.tsx
@@ -27,7 +27,7 @@ if (module.hot) {
   module.hot.accept('./components/App', () => {
     try {
       renderApp();
-    } catch (err) {
+    } catch (err: any) {
       import('./components/ErrorBox').then(({ default: ErrorBox }) => {
         root.render(<ErrorBox error={err} />);
       });


### PR DESCRIPTION
For brand new react projects the compiler now panics when we try to pass `err: unknown` as a prop to the ErrorBox. This is the simplest fix. Open to other "proper" ways to get it done other than `any`.