### PR TITLE
Fix websocket connection URL

### DIFF
--- a/src/config/webpackDevServer.js
+++ b/src/config/webpackDevServer.js
@@ -17,7 +17,8 @@ module.exports.getWebpackDevServerConfig = async () => {
       allowedHosts: 'all',
       client: {
         logging: 'warn',
-        overlay: true
+        overlay: true,
+        webSocketURL: `wss://${host}:${port}/ws`
       },
       devMiddleware: {
         publicPath: `http${https ? 's' : ''}://${host}:${port}/`

--- a/src/config/webpackDevServer.js
+++ b/src/config/webpackDevServer.js
@@ -18,7 +18,7 @@ module.exports.getWebpackDevServerConfig = async () => {
       client: {
         logging: 'warn',
         overlay: true,
-        webSocketURL: `wss://${host}:${port}/ws`
+        webSocketURL: `ws${https ? 's' : ''}://${host}:${port}/ws`
       },
       devMiddleware: {
         publicPath: `http${https ? 's' : ''}://${host}:${port}/`


### PR DESCRIPTION
Re: this issue https://github.com/webpack/webpack-dev-server/issues/1809

We should be able to just define the websocket url here.

Hold on before merge. I'll just test it.