### PR TITLE
add if (isTS) to error handling

### DIFF
--- a/src/generators/project/templates/react/src/index.tsx
+++ b/src/generators/project/templates/react/src/index.tsx
@@ -27,7 +27,7 @@ if (module.hot) {
   module.hot.accept('./components/App', () => {
     try {
       renderApp();
-    } catch (err: any) {
+    } catch (err<% if (isTS) { %>: any<% } %>) {
       import('./components/ErrorBox').then(({ default: ErrorBox }) => {
         root.render(<ErrorBox error={err} />);
       });


### PR DESCRIPTION
Just removes the `: any` from the end of the `err` in the index file, so when a user selects a JS project, they don't get TS.