### PR TITLE
remove setOfValues & use Object.values()

### DIFF
--- a/src/cli/constants.js
+++ b/src/cli/constants.js
@@ -1,7 +1,6 @@
 // Ours
 const { createLogo } = require('../utils/branding');
 const { cmd, dim, hvy, opt, req, sec } = require('../utils/color');
-const { setOfValues } = require('../utils/structures');
 
 const COMMAND_ALIASES = (module.exports.COMMAND_ALIASES = {
   b: 'build',
@@ -14,7 +13,7 @@ const COMMAND_ALIASES = (module.exports.COMMAND_ALIASES = {
   t: 'test'
 });
 
-module.exports.COMMANDS = setOfValues(COMMAND_ALIASES);
+module.exports.COMMANDS = new Set(Object.values(COMMAND_ALIASES));
 
 module.exports.DEFAULTS = {
   name: '__command__',

--- a/src/cli/generate/constants.js
+++ b/src/cli/generate/constants.js
@@ -1,6 +1,5 @@
 // Ours
 const { cmd, hvy, opt, req, sec } = require('../../utils/color');
-const { setOfValues } = require('../../utils/structures');
 
 module.exports.OPTIONS = {
   boolean: ['announce'],
@@ -14,7 +13,7 @@ const GENERATOR_ALIASES = (module.exports.GENERATOR_ALIASES = {
   p: 'project'
 });
 
-module.exports.GENERATORS = setOfValues(GENERATOR_ALIASES);
+module.exports.GENERATORS = new Set(Object.values(GENERATOR_ALIASES));
 
 module.exports.MESSAGES = {
   generatorDoesNotExist: name => `The generator '${name}' does not exist.`,

--- a/src/utils/structures.js
+++ b/src/utils/structures.js
@@ -31,5 +31,3 @@ module.exports.combine = (...sources) => sources.reduce(combine, {});
  * @see combine
  */
 module.exports.merge = (...sources) => sources.reduce(combineDeep, {});
-
-module.exports.setOfValues = source => new Set(Object.keys(source).map(key => source[key]));


### PR DESCRIPTION
I think this syntax is more straightforward syntax and the API has been available since Node v7 (maintenance ended back in 2017). So I think it's a safe change.

I verified it's the same output with this test, and tested generating & building a new project.
```
  it('returns a set of object values', () => {
    const values = { a: 1, b: 2, c: 3, d: 3 };
    expect(setOfValues(values)).toEqual(new Set(Object.values(values)));
  });
```